### PR TITLE
Give every surface one beam-colour convention, and make invisible beams distinguishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the **Blender Optics Simulator** (`optical_alignment_sim`
 here. The format follows [Keep a Changelog](https://keepachangelog.com/), and the project uses
 semantic versioning.
 
+## [Unreleased]
+
+### Fixed — three beam-colour conventions where there should have been one
+- **One colour convention, shared.** `bake.py`, `overlay.py` and `svg_export.py` each carried their
+  own wavelength→RGB curve and they had drifted: the viewport ignored wavelength entirely (every
+  beam red), the SVG used a linear 510–580 nm ramp against the bake's tuned green plateau, and the
+  two disagreed on out-of-band light (dim crimson vs flat grey). A 589 nm beam rendered as three
+  different colours depending on where you looked at it. The convention now lives in one bpy-free
+  module, `beamcolor.py`, with a bare-interpreter self-test; the in-band curve is bit-for-bit the
+  one that shipped in `bake.py`, so existing scenes do not shift hue.
+
+### Added — invisible beams you can actually tell apart
+- **The viewport colours beams by wavelength.** It was drawing every beam the same red regardless
+  of the source's `wavelength`, while the bake and the SVG export already honoured it. An SHG bench
+  now reads IR-in / green-out while you drag it, not only after a bake.
+- **IR and UV ramp instead of flat-lining.** All light above 780 nm used to collapse to one constant
+  dark red, so an OPO bench's 1064 / 1550 / 3394 nm lines were three identical tubes. Colour now
+  keeps moving past the band edge (log-spaced through the IR, so the near-IR where benches actually
+  live is not squashed into a few percent), while staying dim enough to read as invisible light.
+- **`oob_display` scene setting** — *Invisible beams* in the beam panel: `FALSE_COLOR` (default),
+  `HIDE` (drop IR/UV entirely, e.g. to watch a 532 nm harmonic without the pump crossing it), or
+  `VIVID` (full-brightness false colour for figures). It applies identically to the viewport, the
+  bake and the SVG export. Display only — a regression check asserts the trace is byte-identical in
+  all three modes.
+
 ## [0.27.0] — Nothing floats: catalog-true cage hardware and a structural-support gate — 2026-07-28
 
 ### Fixed — hardware that only *looked* mounted

--- a/optical_alignment_sim/__init__.py
+++ b/optical_alignment_sim/__init__.py
@@ -20,7 +20,7 @@ if "properties" in locals():
 
 import sys
 
-from . import (prefs, presets, physics, geometry, properties, operators, mounts, tracer, overlay,
+from . import (prefs, presets, physics, geometry, beamcolor, properties, operators, mounts, tracer, overlay,
                monitor, handlers, alignment, solvers, design, diagnostics, scan, bake, render, library, assembly, ao,
                bridge, elements_generic, optomech, examples_builtin, svg_export, updater, ui, optics_api)
 

--- a/optical_alignment_sim/bake.py
+++ b/optical_alignment_sim/bake.py
@@ -20,10 +20,23 @@ BEAM_MAT = "OPTICS_BEAM"
 _baked_sig = None       # signature of the segments currently baked (so renders never use a stale bake)
 
 
-def _segments_sig(segs):
-    """Cheap hash of the baked beam geometry (segment endpoints)."""
-    return hash(tuple(round(c, 3) for s in segs
-                      for pt in (s["p1"], s["p2"]) for c in pt))
+def _segments_sig(segs, oob=None):
+    """Hash of everything the bake turns into meshes and materials.
+
+    Endpoints are not enough. The tube's SHAPE also follows `kind` (a split-transmitted leg
+    is drawn thinner) and the Gaussian taper (`w_mm`/`qd`/`m2`), and its COLOUR follows the
+    wavelength and the invisible-beam mode. Signing geometry alone let `ensure_beams` keep a
+    stale bake when only the colour had moved: retune a source's wavelength, or switch
+    oob_display, and the render still showed the previous tubes because nothing had moved."""
+    rows = []
+    for s in segs:
+        rows.append((
+            tuple(round(c, 3) for pt in (s["p1"], s["p2"]) for c in pt),
+            s.get("kind"), s.get("wavelength"), s.get("m2"),
+            round(s.get("w_mm") or 0.0, 6),
+            tuple(round(v, 6) for v in (s.get("qd") or ())),
+        ))
+    return hash((oob, tuple(rows)))
 
 
 def beam_collection(scene):
@@ -50,9 +63,13 @@ def beam_material(wl_nm=None, mode='FALSE_COLOR'):
         rgb = beamcolor.wavelength_rgb(wl_nm, mode)
         if rgb is None:                                     # HIDE: this beam is not drawn at all
             return None
-        # the mode is part of the material identity: the same 1064 nm beam is a different
-        # colour under VIVID, and reusing one datablock would silently show the stale one
-        name = "%s_%d_%s" % (BEAM_MAT, int(round(wl_nm)), mode)
+        # The name IS the cache key, so it must separate everything that separates the colour.
+        # The mode belongs in it (the same 1064 nm beam is a different colour under VIVID), and
+        # the wavelength has to keep its decimals: rounding to a whole nm collided any two lines
+        # that round the same way into one datablock, and the second one then silently rendered
+        # in the first one's colour (589.0 and 589.4 nm both key to 589, and differ by 3/255 in
+        # green -- the pair test_optics pins).
+        name = "%s_%.3f_%s" % (BEAM_MAT, float(wl_nm), mode)
         color = tuple(rgb) + (1.0,)
         strength = beamcolor.emission_strength(wl_nm, mode)
     m = bpy.data.materials.get(name)
@@ -180,21 +197,23 @@ def bake_beams(context, radius=0.6):
             r1 = r2 = radius * (0.6 if s["kind"] == 'SPLIT_T' else 1.0)
         if _make_taper(context, "BEAM_%02d" % i, p1, p2, r1, r2, mat, coll):
             n += 1
-    _baked_sig = _segments_sig(tracer.cached_segments)
+    _baked_sig = _segments_sig(tracer.cached_segments, oob)
     return n
 
 
 def ensure_beams(context):
-    """Make sure baked beams exist AND match the current beam path before a render. Re-bakes
-    when the path has changed since the last bake (the old bake would otherwise render stale
-    beams over the moved optics)."""
+    """Make sure baked beams exist AND match what the current scene should draw, before a
+    render. Re-bakes when anything the bake depends on has changed since the last one -- the
+    beam path, but also the wavelengths and the invisible-beam mode, which change the tubes'
+    colour without moving them (the old bake would otherwise render stale beams)."""
     scene = context.scene
     segs = tracer.trace_scene(scene, mode=scene.optics.trace_mode,
                               max_segments=scene.optics.max_segments, max_depth=scene.optics.max_depth)
     tracer.cached_segments = segs
     c = bpy.data.collections.get(BEAM_COLL)
     have = c is not None and any(o.name.startswith("BEAM_") for o in c.objects)
-    if have and _segments_sig(segs) == _baked_sig:
+    oob = getattr(scene.optics, "oob_display", 'FALSE_COLOR')
+    if have and _segments_sig(segs, oob) == _baked_sig:
         return len(c.objects)
     return bake_beams(context)
 

--- a/optical_alignment_sim/bake.py
+++ b/optical_alignment_sim/bake.py
@@ -12,7 +12,7 @@ from bpy.types import Operator
 from bpy.props import FloatProperty
 from mathutils import Vector
 
-from . import tracer
+from . import tracer, beamcolor
 
 BEAM_COLL = "COL_BEAMS"
 BEAM_MAT = "OPTICS_BEAM"
@@ -38,53 +38,23 @@ def beam_collection(scene):
     return c
 
 
-def wavelength_rgb(wl_nm):
-    """Visible-spectrum wavelength -> linear RGB (Bruton-style piecewise approximation).
+def beam_material(wl_nm=None, mode='FALSE_COLOR'):
+    """Per-wavelength emission material (BEAM_MAT for the legacy default, BEAM_MAT_<nm>_<mode>
+    otherwise) so a baked bench shows its real colors -- an SHG bench MUST read IR in / green out.
 
-    VISUALIZATION convention, not radiometry: out-of-band light is invisible in reality, but a
-    black tube reads as "no beam", so IR (>780 nm) renders as a dim deep crimson and UV (<380 nm)
-    as a dim violet -- the standard optics-figure convention (e.g. a 1064 nm pump drawn dark red
-    next to its bright green 532 nm harmonic)."""
-    w = float(wl_nm)
-    if w < 380.0:
-        r, g, b = 0.35, 0.08, 0.55
-    elif w < 440.0:
-        r, g, b = (440.0 - w) / 60.0, 0.0, 1.0
-    elif w < 490.0:
-        r, g, b = 0.0, (w - 440.0) / 50.0, 1.0
-    elif w < 510.0:
-        r, g, b = 0.0, 1.0, (510.0 - w) / 20.0
-    elif w < 545.0:
-        r, g, b = 0.0, 1.0, 0.0                  # green plateau: 532 nm must READ laser-green
-    elif w < 580.0:
-        r, g, b = (w - 545.0) / 35.0, 1.0, 0.0
-    elif w < 645.0:
-        # squared falloff: 633 nm must stay LASER-red under a bright emission (a linear ramp
-        # leaves g=0.19 there, which blooms yellow-orange); 589 nm still reads sodium-yellow
-        r, g, b = 1.0, ((645.0 - w) / 65.0) ** 2, 0.0
-    elif w <= 780.0:
-        r, g, b = 1.0, 0.0, 0.0
-    else:
-        r, g, b = 0.55, 0.02, 0.02
-    # gentle intensity roll-off at the band edges (keeps 633 nm at full brightness)
-    if 380.0 <= w < 420.0:
-        f = 0.3 + 0.7 * (w - 380.0) / 40.0
-        r, g, b = r * f, g * f, b * f
-    elif 700.0 < w <= 780.0:
-        f = 0.3 + 0.7 * (780.0 - w) / 80.0
-        r, g, b = r * f, g * f, b * f
-    return r, g, b
-
-
-def beam_material(wl_nm=None):
-    """Per-wavelength emission material (BEAM_MAT for the legacy default, BEAM_MAT_<nm> otherwise)
-    so a baked bench shows its real colors -- an SHG bench MUST read IR in / green out."""
+    The colour convention lives in `beamcolor`, shared with the viewport overlay and the SVG
+    export. Returns None when `mode` hides this wavelength, so the caller skips the tube."""
     if wl_nm is None:
-        name, color = BEAM_MAT, (1.0, 0.08, 0.04, 1.0)      # legacy default (633-class red)
+        name, color, strength = BEAM_MAT, (1.0, 0.08, 0.04, 1.0), 25.0   # legacy default (633-class red)
     else:
-        name = "%s_%d" % (BEAM_MAT, int(round(wl_nm)))
-        r, g, b = wavelength_rgb(wl_nm)
-        color = (r, g, b, 1.0)
+        rgb = beamcolor.wavelength_rgb(wl_nm, mode)
+        if rgb is None:                                     # HIDE: this beam is not drawn at all
+            return None
+        # the mode is part of the material identity: the same 1064 nm beam is a different
+        # colour under VIVID, and reusing one datablock would silently show the stale one
+        name = "%s_%d_%s" % (BEAM_MAT, int(round(wl_nm)), mode)
+        color = tuple(rgb) + (1.0,)
+        strength = beamcolor.emission_strength(wl_nm, mode)
     m = bpy.data.materials.get(name)
     if m:
         return m
@@ -94,8 +64,7 @@ def beam_material(wl_nm=None):
     nt.nodes.clear()
     em = nt.nodes.new("ShaderNodeEmission")
     em.inputs["Color"].default_value = color
-    # out-of-band tubes glow dimmer: an IR pump should read as a dark ember next to its harmonic
-    em.inputs["Strength"].default_value = 25.0 if (wl_nm is None or 380.0 <= wl_nm <= 780.0) else 14.0
+    em.inputs["Strength"].default_value = strength
     out = nt.nodes.new("ShaderNodeOutputMaterial")
     nt.links.new(em.outputs["Emission"], out.inputs["Surface"])
     return m
@@ -194,8 +163,11 @@ def bake_beams(context, radius=0.6):
     clear_baked(scene)
     coll = beam_collection(scene)
     n = 0
+    oob = getattr(scene.optics, "oob_display", 'FALSE_COLOR')
     for i, s in enumerate(tracer.cached_segments):
-        mat = beam_material(s.get("wavelength"))     # per-segment color: SHG green != pump IR
+        mat = beam_material(s.get("wavelength"), oob)  # per-segment color: SHG green != pump IR
+        if mat is None:                                # hidden by the invisible-beam mode (IR/UV)
+            continue
         p1, p2 = Vector(s["p1"]), Vector(s["p2"])
         qd = s.get("qd")
         if qd is not None:                              # taper to the real Gaussian w(z) along the segment

--- a/optical_alignment_sim/beamcolor.py
+++ b/optical_alignment_sim/beamcolor.py
@@ -1,0 +1,264 @@
+"""Beam colour convention: wavelength -> RGB, for every visualization surface.
+
+ONE source of truth. `bake.py` (render materials), `overlay.py` (viewport) and
+`svg_export.py` (schematic figures) all call `wavelength_rgb()` here, so a 589 nm beam
+reads the same sodium-yellow while you drag it, when you render it, and in the exported
+figure. Before this module each of the three carried its own copy of the curve and they
+had drifted apart (different green plateau, different out-of-band handling).
+
+This is a VISUALIZATION convention, not radiometry. Out-of-band light is invisible in
+reality, but a black tube reads as "no beam" on a bench you are trying to design, so IR
+and UV get a false colour by default -- the standard optics-figure convention (a 1064 nm
+pump drawn dark red next to its bright green 532 nm harmonic).
+
+The out-of-band ramp exists because a *constant* out-of-band colour is not enough: an OPO
+bench carries 1064 / 1550 / 3394 nm at once, and three identical dark-red lines cannot be
+told apart. Colour therefore keeps moving past the band edge (dim, but distinguishable).
+
+bpy-free on purpose, so it self-tests in a bare interpreter:
+
+    python3 optical_alignment_sim/beamcolor.py
+"""
+from __future__ import annotations
+
+import math
+
+# The human visible band. In-band colour is the curve that shipped in bake.py and is kept
+# bit-for-bit: existing scenes must not shift hue because this module appeared.
+VISIBLE_MIN_NM = 380.0
+VISIBLE_MAX_NM = 780.0
+
+# Ramp ends, taken from the widest transparency window in physics.GLASS_RANGE_UM so the ramp
+# never saturates on a bench this add-on can actually build: ZnSe reaches 18.2 um (Ge's 14 um
+# and the CO2 line at 10.6 um sit inside it), and the shortest UV edge is 0.20 um (MgF2,
+# crystal quartz). Beyond these the ramp clamps and colours collapse again -- which is the
+# failure the ramp exists to prevent, so widen these before adding a more exotic material.
+IR_RAMP_MAX_NM = 18200.0
+UV_RAMP_MIN_NM = 100.0
+
+# How an out-of-band beam is drawn. In-band beams ignore this entirely.
+OOB_MODES = ('FALSE_COLOR', 'HIDE', 'VIVID')
+
+# Emission strength for the baked beam material: out-of-band glows dimmer so an IR pump
+# reads as a dark ember next to its harmonic. VIVID drops that penalty on purpose.
+EMISSION_IN_BAND = 25.0
+EMISSION_OUT_OF_BAND = 14.0
+
+# FALSE_COLOR ramps. The t=0 stop of each is the constant colour this used to be, so a
+# beam sitting just past the band edge does not jump now that the ramp exists.
+_IR_STOPS = ((0.0, (0.55, 0.02, 0.02)),      # 780 nm  deep crimson (the legacy constant)
+             (0.35, (0.42, 0.16, 0.05)),     # ~2.4 um brick
+             (1.0, (0.30, 0.22, 0.18)))      # 18.2 um warm grey
+_UV_STOPS = ((0.0, (0.35, 0.08, 0.55)),      # 380 nm  violet (the legacy constant)
+             (0.5, (0.18, 0.06, 0.60)),      # ~240 nm deep blue-violet
+             (1.0, (0.10, 0.03, 0.45)))      # 100 nm  near-black indigo
+
+# VIVID ramps: full brightness, for figures where the invisible beams still have to be the
+# subject. Keeps the warm=IR / cool=UV intuition so the direction is still readable.
+_IR_VIVID = ((0.0, (1.0, 0.15, 0.0)),
+             (0.5, (1.0, 0.45, 0.0)),
+             (1.0, (1.0, 0.85, 0.10)))
+_UV_VIVID = ((0.0, (0.65, 0.25, 1.0)),
+             (0.5, (0.35, 0.35, 1.0)),
+             (1.0, (0.15, 0.75, 1.0)))
+
+
+def _visible_rgb(w):
+    """Visible-band wavelength -> linear RGB (Bruton-style piecewise approximation).
+
+    Unchanged from the curve that shipped in bake.py, including the two shaping choices
+    tuned against real laser lines: the flat green plateau (532 nm must READ laser-green)
+    and the squared red falloff (633 nm must stay laser-red rather than blooming
+    yellow-orange, while 589 nm still reads sodium-yellow)."""
+    if w < 440.0:
+        r, g, b = (440.0 - w) / 60.0, 0.0, 1.0
+    elif w < 490.0:
+        r, g, b = 0.0, (w - 440.0) / 50.0, 1.0
+    elif w < 510.0:
+        r, g, b = 0.0, 1.0, (510.0 - w) / 20.0
+    elif w < 545.0:
+        r, g, b = 0.0, 1.0, 0.0
+    elif w < 580.0:
+        r, g, b = (w - 545.0) / 35.0, 1.0, 0.0
+    elif w < 645.0:
+        r, g, b = 1.0, ((645.0 - w) / 65.0) ** 2, 0.0
+    else:
+        r, g, b = 1.0, 0.0, 0.0
+    # gentle intensity roll-off at the band edges (keeps 633 nm at full brightness)
+    if w < 420.0:
+        f = 0.3 + 0.7 * (w - 380.0) / 40.0
+    elif w > 700.0:
+        f = 0.3 + 0.7 * (780.0 - w) / 80.0
+    else:
+        f = 1.0
+    return r * f, g * f, b * f
+
+
+def _ramp(stops, t):
+    """Piecewise-linear interpolation through (position, rgb) stops; t clamped to [0, 1]."""
+    t = 0.0 if t < 0.0 else (1.0 if t > 1.0 else t)
+    for (t0, c0), (t1, c1) in zip(stops, stops[1:]):
+        if t <= t1:
+            f = 0.0 if t1 <= t0 else (t - t0) / (t1 - t0)
+            return tuple(a + (b - a) * f for a, b in zip(c0, c1))
+    return stops[-1][1]
+
+
+def is_out_of_band(wl_nm):
+    """True if this wavelength is invisible to the eye (and so subject to the OOB mode)."""
+    return not (VISIBLE_MIN_NM <= float(wl_nm) <= VISIBLE_MAX_NM)
+
+
+def wavelength_rgb(wl_nm, mode='FALSE_COLOR'):
+    """Wavelength (nm) -> linear RGB in 0..1, or **None** when the beam should not be drawn.
+
+    In-band light ignores `mode` and always gets its true colour. Out-of-band light follows
+    the scene's OOB mode:
+
+    - ``FALSE_COLOR`` (default) dim IR/UV ramps -- visible, distinguishable, and still
+      legible as "this light is not really visible".
+    - ``HIDE`` returns None; the caller drops the beam. Lets you watch only the 532 nm
+      harmonic on an SHG bench without the pump crossing it.
+    - ``VIVID`` full-brightness false colour, for figures where the invisible beam is the
+      point. Explicitly non-physical.
+
+    A None return is the *only* falsy result; callers must test ``is None``, not truthiness
+    (black, (0, 0, 0), is a legitimate colour)."""
+    w = float(wl_nm)
+    if VISIBLE_MIN_NM <= w <= VISIBLE_MAX_NM:
+        return _visible_rgb(w)
+    if mode == 'HIDE':
+        return None
+    vivid = (mode == 'VIVID')
+    if w > VISIBLE_MAX_NM:
+        # log position: IR spans 780 nm -> 14 um, so a linear ramp would squash the whole
+        # near-IR (where the benches actually live) into the first few percent
+        span = math.log(IR_RAMP_MAX_NM / VISIBLE_MAX_NM)
+        t = math.log(max(w, VISIBLE_MAX_NM) / VISIBLE_MAX_NM) / span
+        return _ramp(_IR_VIVID if vivid else _IR_STOPS, t)
+    t = (VISIBLE_MIN_NM - w) / (VISIBLE_MIN_NM - UV_RAMP_MIN_NM)
+    return _ramp(_UV_VIVID if vivid else _UV_STOPS, t)
+
+
+def emission_strength(wl_nm, mode='FALSE_COLOR'):
+    """Emission node strength for the baked beam material (see EMISSION_* above)."""
+    if mode == 'VIVID' or not is_out_of_band(wl_nm):
+        return EMISSION_IN_BAND
+    return EMISSION_OUT_OF_BAND
+
+
+def wavelength_rgb255(wl_nm, mode='FALSE_COLOR'):
+    """As `wavelength_rgb`, quantized to 0-255 ints for SVG/CSS. None stays None."""
+    c = wavelength_rgb(wl_nm, mode)
+    if c is None:
+        return None
+    return tuple(int(255 * v) for v in c)
+
+
+if __name__ == "__main__":
+    import sys
+
+    fails = []
+
+    def close(a, b, tol=1e-9):
+        return abs(a - b) <= tol
+
+    # --- 1. in-band colour is bit-for-bit the curve that shipped in bake.py -------------
+    def _legacy_bake_rgb(w):
+        """The pre-refactor bake.wavelength_rgb, transcribed to pin the in-band curve."""
+        if w < 380.0:
+            r, g, b = 0.35, 0.08, 0.55
+        elif w < 440.0:
+            r, g, b = (440.0 - w) / 60.0, 0.0, 1.0
+        elif w < 490.0:
+            r, g, b = 0.0, (w - 440.0) / 50.0, 1.0
+        elif w < 510.0:
+            r, g, b = 0.0, 1.0, (510.0 - w) / 20.0
+        elif w < 545.0:
+            r, g, b = 0.0, 1.0, 0.0
+        elif w < 580.0:
+            r, g, b = (w - 545.0) / 35.0, 1.0, 0.0
+        elif w < 645.0:
+            r, g, b = 1.0, ((645.0 - w) / 65.0) ** 2, 0.0
+        elif w <= 780.0:
+            r, g, b = 1.0, 0.0, 0.0
+        else:
+            r, g, b = 0.55, 0.02, 0.02
+        if 380.0 <= w < 420.0:
+            f = 0.3 + 0.7 * (w - 380.0) / 40.0
+        elif 700.0 < w <= 780.0:
+            f = 0.3 + 0.7 * (780.0 - w) / 80.0
+        else:
+            f = 1.0
+        return r * f, g * f, b * f
+
+    w = VISIBLE_MIN_NM
+    while w <= VISIBLE_MAX_NM:
+        got, want = wavelength_rgb(w), _legacy_bake_rgb(w)
+        if not all(close(a, b) for a, b in zip(got, want)):
+            fails.append("in-band %.1f nm drifted: %s != legacy %s" % (w, got, want))
+            break
+        w += 0.5
+
+    # real laser lines must still read as themselves
+    if wavelength_rgb(532.0) != (0.0, 1.0, 0.0):
+        fails.append("532 nm is not pure laser-green: %s" % (wavelength_rgb(532.0),))
+    if not (wavelength_rgb(632.8)[0] == 1.0 and wavelength_rgb(632.8)[1] < 0.05):
+        fails.append("632.8 nm is not laser-red: %s" % (wavelength_rgb(632.8),))
+
+    # --- 2. the band edges are continuous with the old constants ------------------------
+    for edge, legacy in ((VISIBLE_MAX_NM + 1e-9, (0.55, 0.02, 0.02)),
+                         (VISIBLE_MIN_NM - 1e-9, (0.35, 0.08, 0.55))):
+        got = wavelength_rgb(edge)
+        if not all(close(a, b, 1e-6) for a, b in zip(got, legacy)):
+            fails.append("band edge %.1f jumps: %s != legacy constant %s" % (edge, got, legacy))
+
+    # --- 3. the whole point: out-of-band lines are DISTINGUISHABLE ----------------------
+    def sep(a, b):
+        return max(abs(x - y) for x, y in zip(wavelength_rgb(a), wavelength_rgb(b)))
+
+    # an OPO bench: pump / signal / idler must not collapse to one colour (they used to)
+    for a, b in ((1064.0, 1550.0), (1550.0, 3393.4), (1064.0, 3393.4)):
+        if sep(a, b) < 0.02:
+            fails.append("IR %.0f vs %.0f nm indistinguishable (max channel delta %.4f)"
+                         % (a, b, sep(a, b)))
+    # Nd:YAG 3rd vs 4th harmonic in the UV
+    if sep(354.67, 266.0) < 0.02:
+        fails.append("UV 355 vs 266 nm indistinguishable (max channel delta %.4f)"
+                     % sep(354.67, 266.0))
+
+    # the ramp must be monotone in the red channel, so "redder = nearer the visible" holds
+    ir = [wavelength_rgb(x)[0] for x in (800.0, 1064.0, 1550.0, 3393.4, 10600.0)]
+    if any(b > a + 1e-12 for a, b in zip(ir, ir[1:])):
+        fails.append("IR red channel is not monotone decreasing: %s" % (ir,))
+
+    # --- 4. modes ----------------------------------------------------------------------
+    if wavelength_rgb(1064.0, 'HIDE') is not None:
+        fails.append("HIDE did not drop an out-of-band beam")
+    if wavelength_rgb(532.0, 'HIDE') is None:
+        fails.append("HIDE dropped an IN-band beam (it must only affect IR/UV)")
+    for mode in OOB_MODES:                       # in-band is mode-independent
+        if wavelength_rgb(632.8, mode) != wavelength_rgb(632.8):
+            fails.append("in-band colour changed under mode %s" % mode)
+    if not (sum(wavelength_rgb(1064.0, 'VIVID')) > sum(wavelength_rgb(1064.0)) + 0.5):
+        fails.append("VIVID is not brighter than FALSE_COLOR at 1064 nm")
+    if emission_strength(1064.0) >= emission_strength(532.0):
+        fails.append("out-of-band emission is not dimmer than in-band")
+    if emission_strength(1064.0, 'VIVID') != EMISSION_IN_BAND:
+        fails.append("VIVID did not drop the out-of-band emission penalty")
+
+    # --- 5. range hygiene: every channel stays in gamut, nothing returns NaN ------------
+    for mode in OOB_MODES:
+        for x in (1.0, 100.0, 200.0, 380.0, 532.0, 780.0, 781.0, 5000.0, 14000.0, 50000.0):
+            c = wavelength_rgb(x, mode)
+            if c is None:
+                continue
+            if not all(0.0 <= v <= 1.0 and v == v for v in c):
+                fails.append("out of gamut at %.1f nm mode %s: %s" % (x, mode, c))
+
+    if fails:
+        print("BEAMCOLOR SELFTEST FAILED:")
+        for f in fails:
+            print("  -", f)
+        sys.exit(1)
+    print("BEAMCOLOR SELFTEST PASSED")

--- a/optical_alignment_sim/beamcolor.py
+++ b/optical_alignment_sim/beamcolor.py
@@ -28,13 +28,15 @@ import math
 VISIBLE_MIN_NM = 380.0
 VISIBLE_MAX_NM = 780.0
 
-# Ramp ends, taken from the widest transparency window in physics.GLASS_RANGE_UM so the ramp
-# never saturates on a bench this add-on can actually build: ZnSe reaches 18.2 um (Ge's 14 um
-# and the CO2 line at 10.6 um sit inside it), and the shortest UV edge is 0.20 um (MgF2,
-# crystal quartz). Beyond these the ramp clamps and colours collapse again -- which is the
-# failure the ramp exists to prevent, so widen these before adding a more exotic material.
+# Ramp ends: the outermost transparency edges in physics.GLASS_RANGE_UM, so the ramp spends
+# its whole range on light a bench in this add-on can actually carry. ZnSe reaches 18.2 um
+# (Ge's 14 um and the CO2 line at 10.6 um sit inside it); the shortest UV edge is 0.20 um
+# (MgF2, crystal quartz). Past these the ramp clamps and colours collapse again -- the very
+# failure it exists to prevent -- so widen them before adding a more exotic material. A line
+# outside every material's window clamps to the end stop, which is the honest reading: no
+# optic in this catalog claims to transmit it.
 IR_RAMP_MAX_NM = 18200.0
-UV_RAMP_MIN_NM = 100.0
+UV_RAMP_MIN_NM = 200.0
 
 # How an out-of-band beam is drawn. In-band beams ignore this entirely.
 OOB_MODES = ('FALSE_COLOR', 'HIDE', 'VIVID')
@@ -50,8 +52,8 @@ _IR_STOPS = ((0.0, (0.55, 0.02, 0.02)),      # 780 nm  deep crimson (the legacy 
              (0.35, (0.42, 0.16, 0.05)),     # ~2.4 um brick
              (1.0, (0.30, 0.22, 0.18)))      # 18.2 um warm grey
 _UV_STOPS = ((0.0, (0.35, 0.08, 0.55)),      # 380 nm  violet (the legacy constant)
-             (0.5, (0.18, 0.06, 0.60)),      # ~240 nm deep blue-violet
-             (1.0, (0.10, 0.03, 0.45)))      # 100 nm  near-black indigo
+             (0.5, (0.18, 0.06, 0.60)),      # 290 nm  deep blue-violet
+             (1.0, (0.10, 0.03, 0.45)))      # 200 nm  near-black indigo
 
 # VIVID ramps: full brightness, for figures where the invisible beams still have to be the
 # subject. Keeps the warm=IR / cool=UV intuition so the direction is still readable.

--- a/optical_alignment_sim/overlay.py
+++ b/optical_alignment_sim/overlay.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import bpy
 
-from . import tracer, geometry
+from . import tracer, geometry, beamcolor
 
 _handle = None
 _line_shader = None
@@ -29,10 +29,19 @@ def _shaders():
     return _line_shader, _point_shader
 
 
-def _color_for(kind):
-    if kind == 'SPLIT_T':
-        return (1.0, 0.55, 0.15, 0.6)      # beam-splitter transmitted: dim orange
-    return (1.0, 0.12, 0.05, 0.95)         # main beam: red
+def _color_for(kind, wl_nm=None, mode='FALSE_COLOR'):
+    """RGBA for a segment, or None when the invisible-beam mode hides this wavelength.
+
+    Colour comes from `beamcolor`, the same convention the bake and the SVG export use, so a
+    532 nm beam is the same green in all three. Kind still shapes the ALPHA: a beam-splitter's
+    transmitted leg stays faded so the two legs read apart at a shared wavelength."""
+    alpha = 0.6 if kind == 'SPLIT_T' else 0.95
+    if wl_nm is None:                      # no wavelength on the segment: the legacy red
+        return (1.0, 0.55, 0.15, alpha) if kind == 'SPLIT_T' else (1.0, 0.12, 0.05, alpha)
+    rgb = beamcolor.wavelength_rgb(wl_nm, mode)
+    if rgb is None:
+        return None
+    return tuple(rgb) + (alpha,)
 
 
 def _draw():
@@ -52,18 +61,24 @@ def _draw():
             return
         line_sh, point_sh = _shaders()
 
+        oob = getattr(sp, "oob_display", 'FALSE_COLOR') if sp else 'FALSE_COLOR'
+        # group by (kind, colour): one draw call per distinct beam colour, so a bench with a
+        # pump and its harmonic costs two, not one per segment
         groups = {}
         for s in segs:
-            groups.setdefault(s["kind"], []).extend([s["p1"], s["p2"]])
+            col = _color_for(s["kind"], s.get("wavelength"), oob)
+            if col is None:                   # hidden by the invisible-beam mode (IR/UV)
+                continue
+            groups.setdefault((s["kind"], col), []).extend([s["p1"], s["p2"]])
 
         gpu.state.blend_set('ALPHA')
         gpu.state.depth_test_set('LESS_EQUAL')
         try:
             line_sh.bind()
             line_sh.uniform_float("viewportSize", (region.width, region.height))
-            for kind, coords in groups.items():
+            for (kind, col), coords in groups.items():
                 line_sh.uniform_float("lineWidth", width if kind != 'SPLIT_T' else max(1.0, width * 0.6))
-                line_sh.uniform_float("color", _color_for(kind))
+                line_sh.uniform_float("color", col)
                 batch_for_shader(line_sh, 'LINES', {"pos": coords}).draw(line_sh)
 
             if show_ports and point_sh is not None:

--- a/optical_alignment_sim/properties.py
+++ b/optical_alignment_sim/properties.py
@@ -773,6 +773,21 @@ class OpticalSceneProps(PropertyGroup):
     max_depth: IntProperty(default=12, min=1, max=64)
     line_width: FloatProperty(name="Beam width", default=3.0, min=0.5, max=10.0)
     show_ports: BoolProperty(name="Show ports", default=True)
+    # How IR / UV beams are DRAWN (viewport, bake and SVG alike). Display only -- the trace is
+    # untouched, so switching this never changes a power, a Jones vector or a segment count.
+    oob_display: EnumProperty(
+        name="Invisible beams",
+        description=("How to draw light the eye cannot see (IR above 780 nm, UV below 380 nm). "
+                     "Affects the viewport, the baked beams and the SVG export identically"),
+        items=[('FALSE_COLOR', "False colour",
+                "Dim IR/UV ramp: visible and distinguishable (1064 vs 1550 nm differ), but still "
+                "reads as invisible light"),
+               ('HIDE',        "Hide",
+                "Do not draw them at all -- watch only the 532 nm harmonic without the pump crossing it"),
+               ('VIVID',       "Vivid",
+                "Full-brightness false colour for figures where the invisible beam is the subject "
+                "(explicitly non-physical)")],
+        default='FALSE_COLOR')
     auto_color: BoolProperty(name="Auto color by alignment", default=True)
     bg_preset: EnumProperty(
         name="Background",

--- a/optical_alignment_sim/svg_export.py
+++ b/optical_alignment_sim/svg_export.py
@@ -11,31 +11,7 @@ import bpy
 from bpy.types import Operator
 from bpy.props import StringProperty
 
-
-def wavelength_rgb(nm):
-    """Approximate visible-spectrum colour (Bruton) for nm in ~[380, 780]; grey outside."""
-    nm = float(nm)
-    if nm < 380.0 or nm > 780.0:
-        return (180, 180, 180)
-    if nm < 440.0:
-        r, g, b = -(nm - 440.0) / 60.0, 0.0, 1.0
-    elif nm < 490.0:
-        r, g, b = 0.0, (nm - 440.0) / 50.0, 1.0
-    elif nm < 510.0:
-        r, g, b = 0.0, 1.0, -(nm - 510.0) / 20.0
-    elif nm < 580.0:
-        r, g, b = (nm - 510.0) / 70.0, 1.0, 0.0
-    elif nm < 645.0:
-        r, g, b = 1.0, -(nm - 645.0) / 65.0, 0.0
-    else:
-        r, g, b = 1.0, 0.0, 0.0
-    if nm < 420.0:
-        f = 0.3 + 0.7 * (nm - 380.0) / 40.0
-    elif nm > 700.0:
-        f = 0.3 + 0.7 * (780.0 - nm) / 80.0
-    else:
-        f = 1.0
-    return (int(255 * r * f), int(255 * g * f), int(255 * b * f))
+from . import beamcolor
 
 
 # per-type glyph fill (loosely mirrors the viewport material families)
@@ -56,8 +32,11 @@ def _esc(s):
     return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def build_svg(state, width=900, margin=64):
-    """Return an SVG document string for the optical state (optics_api.get_state() shape)."""
+def build_svg(state, width=900, margin=64, oob='FALSE_COLOR'):
+    """Return an SVG document string for the optical state (optics_api.get_state() shape).
+
+    `oob` is the scene's invisible-beam mode (see `beamcolor`): it decides how IR/UV beams are
+    coloured here, identically to the viewport and the bake. Under 'HIDE' they are omitted."""
     elems = state.get("elements", [])
     beams = state.get("beam_path", [])
     pts = [(e["world_center"][0], e["world_center"][1]) for e in elems]
@@ -89,8 +68,11 @@ def build_svg(state, width=900, margin=64):
            'font-family="sans-serif">' % (width, height, width, height),
            '<rect width="100%%" height="100%%" fill="#0d0e12"/>']
     for s in beams:                                          # beam path
+        rgb = beamcolor.wavelength_rgb255(s.get("wavelength", 632.8), oob)
+        if rgb is None:                                      # hidden by the invisible-beam mode
+            continue
         x1, y1, x2, y2 = X(s["p1"][0]), Y(s["p1"][1]), X(s["p2"][0]), Y(s["p2"][1])
-        r, g, b = wavelength_rgb(s.get("wavelength", 632.8))
+        r, g, b = rgb
         p = max(min(float(s.get("power", 1.0)), 1.0), 0.0)
         dash = ' stroke-dasharray="5,4"' if s.get("kind") == 'SPLIT_T' else ''
         out.append('<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="rgb(%d,%d,%d)" '
@@ -117,9 +99,10 @@ def export_svg(filepath):
     """Write a top-view SVG schematic of the current scene to filepath. {ok, path, elements, beams}."""
     from . import optics_api
     state = optics_api.get_state()
+    oob = getattr(bpy.context.scene.optics, "oob_display", 'FALSE_COLOR')
     path = bpy.path.abspath(filepath) if str(filepath).startswith("//") else filepath
     with open(path, "w") as f:
-        f.write(build_svg(state))
+        f.write(build_svg(state, oob=oob))
     return {"ok": True, "path": path, "elements": len(state.get("elements", [])),
             "beams": len(state.get("beam_path", []))}
 

--- a/optical_alignment_sim/ui.py
+++ b/optical_alignment_sim/ui.py
@@ -395,6 +395,7 @@ class OPTICS_PT_trace_settings(_OpticsPanel, Panel):
             col = layout.column(align=True)
             col.prop(props, "line_width")
             col.prop(props, "show_ports")
+            col.prop(props, "oob_display")
             col.prop(props, "auto_color")
             col.prop(props, "max_segments")
             col.prop(props, "max_depth")

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2115,21 +2115,36 @@ _wls = {round(s.get("wavelength", 0.0)) for s in _segs_before}
 check("SHG bench carries both an out-of-band and an in-band line (the case under test)",
       any(beamcolor.is_out_of_band(w) for w in _wls) and any(not beamcolor.is_out_of_band(w) for w in _wls))
 
-# the mode must NEVER reach the tracer: same segment count, same per-field power/wavelength/opl
+# the mode must NEVER reach the tracer. Digest EVERY field the tracer emits -- geometry
+# (p1/p2/kind/from/to/parent), fields (power/wavelength/jones/opl/phase/coh), the Gaussian
+# (qd/w_mm/m2) and aberr -- not a hand-picked subset, or "byte-identical" would be claiming
+# more than the check tests.
+def _seg_digest(segs):
+    rows = []
+    for _s in segs:
+        _row = []
+        for _k in sorted(_s):
+            _v = _s[_k]
+            if hasattr(_v, "to_tuple"):          # mathutils Vector -> stable repr
+                _v = tuple(_v)
+            _row.append("%s=%r" % (_k, _v))
+        rows.append("|".join(_row))
+    return "\n".join(rows)
+
+_digest_before = _seg_digest(_segs_before)
+_digest_keys = set().union(*(set(s) for s in _segs_before))
 _same = True
 for _mode in beamcolor.OOB_MODES:
     sc.optics.oob_display = _mode
     _segs = tracer.trace_scene(sc, mode=sc.optics.trace_mode, max_segments=sc.optics.max_segments,
                                max_depth=sc.optics.max_depth)
-    if len(_segs) != len(_segs_before):
+    if len(_segs) != len(_segs_before) or _seg_digest(_segs) != _digest_before:
         _same = False
         break
-    for _a, _b in zip(_segs, _segs_before):
-        if (_a.get("power") != _b.get("power") or _a.get("wavelength") != _b.get("wavelength")
-                or _a.get("opl") != _b.get("opl")):
-            _same = False
-            break
-check("oob_display is display-only: the trace is byte-identical in all three modes", _same)
+check("oob_display is display-only: the FULL segment digest is identical in all three modes", _same)
+# guard the guard: a digest over an accidentally-empty field set would pass vacuously
+check("that digest actually covers the trace's physics fields (not a vacuous compare)",
+      {"p1", "p2", "kind", "power", "wavelength", "jones", "opl", "qd", "m2", "parent"} <= _digest_keys)
 
 # HIDE drops exactly the invisible tubes and keeps the visible ones
 sc.optics.oob_display = 'HIDE'

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2158,6 +2158,60 @@ bake.clear_baked(sc)
 check("HIDE bakes fewer beam tubes than FALSE_COLOR (the IR ones are dropped)",
       0 < _n_hidden < _n_shown)
 
+# The render path is ensure_beams(), not bake_beams(): it SKIPS the re-bake when its signature
+# matches. A colour-only change moves NOTHING, so a signature over endpoints alone kept the
+# previous tubes and rendered stale colour. Both cases below hold the geometry fixed on purpose
+# -- if the layout moved, the old endpoint-only signature would have caught it and these would
+# prove nothing.
+def _endpoints(segs):
+    return [tuple(round(c, 3) for pt in (s["p1"], s["p2"]) for c in pt) for s in segs]
+
+def _beam_mats():
+    return {o.active_material.name for o in sc.objects
+            if o.name.startswith("BEAM_") and o.active_material}
+
+sc.optics.oob_display = 'FALSE_COLOR'
+bake.bake_beams(bpy.context)
+_ep0, _n0, _mats0 = _endpoints(tracer.cached_segments), _n_shown, _beam_mats()
+
+# (1) mode change alone -> ensure_beams must notice
+sc.optics.oob_display = 'HIDE'
+bake.ensure_beams(bpy.context)
+_n_after_mode = sum(1 for o in sc.objects if o.name.startswith("BEAM_"))
+check("ensure_beams re-bakes on a MODE change alone (geometry byte-identical, tube count drops)",
+      _endpoints(tracer.cached_segments) == _ep0 and _n_after_mode < _n0)
+
+sc.optics.oob_display = 'VIVID'
+bake.ensure_beams(bpy.context)
+check("ensure_beams re-bakes FALSE_COLOR -> VIVID (same tubes, different materials)",
+      _endpoints(tracer.cached_segments) == _ep0 and _beam_mats() != _mats0)
+
+# (2) wavelength change alone -> retune the pump; the bench does not move
+sc.optics.oob_display = 'FALSE_COLOR'
+bake.ensure_beams(bpy.context)
+_mats_fc = _beam_mats()
+_wsrc = next(o for o in sc.objects if o.optics.element_type == 'SOURCE')
+_wsrc.optics.wavelength = 1030.0
+bpy.context.view_layer.update()
+bake.ensure_beams(bpy.context)
+check("ensure_beams re-bakes on a WAVELENGTH change alone (new materials, layout unmoved)",
+      _endpoints(tracer.cached_segments) == _ep0 and _beam_mats() != _mats_fc)
+
+# The material name is the cache key, so two lines that render DIFFERENT colours must not
+# share one datablock. 589.0 / 589.4 is the case that broke: both round to 589 nm, so the
+# old integer key handed the second line the first one's material. (589.6 would round to 590
+# and pass either way -- it proves nothing, which is why the pair matters.)
+_m589a, _m589b = bake.beam_material(589.0, 'FALSE_COLOR'), bake.beam_material(589.4, 'FALSE_COLOR')
+check("beam materials keep same-rounding lines apart (589.0 vs 589.4 are two datablocks)",
+      _m589a is not _m589b)
+check("...and those two datablocks really do carry different colours",
+      tuple(_m589a.node_tree.nodes["Emission"].inputs["Color"].default_value)[:3]
+      != tuple(_m589b.node_tree.nodes["Emission"].inputs["Color"].default_value)[:3])
+
+_wsrc.optics.wavelength = 1064.0                      # restore the bench for the checks below
+bpy.context.view_layer.update()
+bake.clear_baked(sc)
+
 # the three surfaces agree: bake material colour == overlay colour == SVG colour, per wavelength
 sc.optics.oob_display = 'FALSE_COLOR'
 _mat = bake.beam_material(1064.0, 'FALSE_COLOR')

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2103,6 +2103,69 @@ bake.clear_baked(sc)
 check("no BEAM_ objects after clear", not any(o.name.startswith("BEAM_") for o in sc.objects))
 check("clear_baked frees beam meshes (no orphan leak)", len(bpy.data.meshes) <= m0)
 
+print("[invisible-beam display mode: one colour convention, DISPLAY-only (trace untouched)]")
+from optical_alignment_sim import beamcolor, svg_export, overlay
+# the green doubler carries 1064 nm in and 532 nm out -- the case the mode exists for
+optics_api.build_example("green_doubler")
+bpy.context.view_layer.update()
+_segs_before = [dict(s) for s in tracer.trace_scene(sc, mode=sc.optics.trace_mode,
+                                                    max_segments=sc.optics.max_segments,
+                                                    max_depth=sc.optics.max_depth)]
+_wls = {round(s.get("wavelength", 0.0)) for s in _segs_before}
+check("SHG bench carries both an out-of-band and an in-band line (the case under test)",
+      any(beamcolor.is_out_of_band(w) for w in _wls) and any(not beamcolor.is_out_of_band(w) for w in _wls))
+
+# the mode must NEVER reach the tracer: same segment count, same per-field power/wavelength/opl
+_same = True
+for _mode in beamcolor.OOB_MODES:
+    sc.optics.oob_display = _mode
+    _segs = tracer.trace_scene(sc, mode=sc.optics.trace_mode, max_segments=sc.optics.max_segments,
+                               max_depth=sc.optics.max_depth)
+    if len(_segs) != len(_segs_before):
+        _same = False
+        break
+    for _a, _b in zip(_segs, _segs_before):
+        if (_a.get("power") != _b.get("power") or _a.get("wavelength") != _b.get("wavelength")
+                or _a.get("opl") != _b.get("opl")):
+            _same = False
+            break
+check("oob_display is display-only: the trace is byte-identical in all three modes", _same)
+
+# HIDE drops exactly the invisible tubes and keeps the visible ones
+sc.optics.oob_display = 'HIDE'
+bake.bake_beams(bpy.context)
+_n_hidden = sum(1 for o in sc.objects if o.name.startswith("BEAM_"))
+bake.clear_baked(sc)
+sc.optics.oob_display = 'FALSE_COLOR'
+bake.bake_beams(bpy.context)
+_n_shown = sum(1 for o in sc.objects if o.name.startswith("BEAM_"))
+bake.clear_baked(sc)
+check("HIDE bakes fewer beam tubes than FALSE_COLOR (the IR ones are dropped)",
+      0 < _n_hidden < _n_shown)
+
+# the three surfaces agree: bake material colour == overlay colour == SVG colour, per wavelength
+sc.optics.oob_display = 'FALSE_COLOR'
+_mat = bake.beam_material(1064.0, 'FALSE_COLOR')
+_mat_rgb = tuple(_mat.node_tree.nodes["Emission"].inputs["Color"].default_value)[:3]
+_ovl_rgb = overlay._color_for('TRANSMIT', 1064.0, 'FALSE_COLOR')[:3]
+_svg_rgb = beamcolor.wavelength_rgb255(1064.0, 'FALSE_COLOR')
+check("bake and overlay draw 1064 nm the same colour",
+      all(abs(a - b) < 1e-6 for a, b in zip(_mat_rgb, _ovl_rgb)))
+check("the SVG export quantizes that same colour (no second convention)",
+      _svg_rgb == tuple(int(255 * v) for v in _ovl_rgb))
+
+# and the reason the ramp exists: an OPO's three IR lines must not collapse to one colour
+check("1064 / 1550 / 3394 nm are three DISTINCT colours (a constant would merge them)",
+      len({beamcolor.wavelength_rgb255(w) for w in (1064.0, 1550.0, 3393.4)}) == 3)
+
+# HIDE removes the beam lines from the SVG too, without emptying the document
+_state = optics_api.get_state()
+_svg_all = svg_export.build_svg(_state, oob='FALSE_COLOR')
+_svg_hidden = svg_export.build_svg(_state, oob='HIDE')
+check("HIDE drops SVG beam lines but keeps the element glyphs",
+      _svg_hidden.count("<line") < _svg_all.count("<line") and "<svg" in _svg_hidden)
+sc.optics.oob_display = 'FALSE_COLOR'
+
 print("[medium-severity tail]")
 # SVG: a Y-dominant (vertical) beamline must not explode the canvas height
 from optical_alignment_sim import svg_export


### PR DESCRIPTION
Raised by #1, where a user asked whether a beam's colour can be driven by
wavelength instead of a hand-picked RGB.

It already could — in two of the three places that draw a beam, with two
different curves.

## The state before

| | out-of-band | in-band |
|---|---|---|
| `bake.py` | IR dim crimson, UV violet, dimmer emission | tuned green plateau, squared red falloff |
| `svg_export.py` | flat grey | linear 510–580 ramp |
| `overlay.py` | — ignored wavelength entirely | two fixed colours |

The same 589 nm beam rendered as three different colours depending on where you
looked at it. The viewport — the surface you actually design against — was the
one that ignored wavelength.

## What this changes

**One convention.** It now lives in `beamcolor.py`: bpy-free, self-testing in a
bare interpreter (`python3 optical_alignment_sim/beamcolor.py`), called by all
three surfaces. The in-band curve is bit-for-bit the one that shipped in
`bake.py` — a self-test walks 380–780 nm at 0.5 nm and compares against a
transcription of the original, so no existing scene shifts hue.

**The viewport honours wavelength.** An SHG bench reads IR-in / green-out while
you drag it, not only after a bake.

**Out-of-band light ramps instead of flat-lining.** Every line above 780 nm used
to be one constant dark red, so an OPO bench's 1064 / 1550 / 3394 nm beams were
three identical tubes. Colour now keeps moving past the band edge, log-spaced
through the IR so the near-IR where benches live is not squashed into a few
percent. Both ramp ends are chosen from the outermost transparency edges in
`physics.GLASS_RANGE_UM` (ZnSe 18.2 µm, MgF2 0.20 µm), so the ramp spends its
range on light a bench here can actually carry. They are constants picked from
that table, not read from it at runtime.

**`oob_display` scene setting** — *Invisible beams*: `FALSE_COLOR` (default),
`HIDE` (drop IR/UV, e.g. watch a 532 nm harmonic without the pump crossing it),
`VIVID` (full-brightness false colour for figures, explicitly non-physical).
Applies identically to viewport, bake and SVG.

## A bug this surfaced

`ensure_beams()` — the path a render actually takes — skips the re-bake when
`_segments_sig` matches, and that signature hashed segment endpoints only. A
colour-only change moves nothing, so retuning a wavelength or switching the mode
left the previous tubes on screen: right geometry, stale colour. The existing
tests never saw it because they called `bake_beams()` directly, which always
rebuilds.

The signature now covers every traced-segment field that affects the baked meshes
or materials, plus the invisible-beam display mode.

Same theme, second collision: the material name keyed on `int(round(wl_nm))`, so
two lines rounding to the same nanometre shared one datablock and the second
silently rendered in the first one's colour. 589.0 and 589.4 nm differ by 3/255
in green and got one material. The key now keeps three decimals.

Both are pinned by regression checks that were **verified against the pre-fix
code**: all five fail without these changes.

## Scope

Display only. The tracer is untouched. A regression check digests **every** field
the tracer emits — position, kind, from/to/parent, power, wavelength, Jones, OPL,
phase, coherence, Gaussian q, w, M², aberr — and asserts it is identical across
all three modes, plus a guard that the digest is not vacuously empty.

## Verification

- `test_optics` **493/493** (was 480/480; +13 new checks)
- `test_validation` **320/320**
- `beamcolor` and `physics` bare self-tests pass under Python 3.13 and 3.9
- `tools/check_release_consistency.py` PASS

No version bump, no CHANGELOG released-section edits, no CITATION changes.

## What is not verified

- **Perceptual separation is unmeasured.** The tests assert the out-of-band lines
  produce *different* RGB values (in the UV, 355 vs 266 nm separate by 0.14 in the
  widest channel, up from 0.04 before the UV bound was corrected). Whether a human
  tells them apart on screen has not been checked.
- **The curve is not colorimetry.** It is a Bruton-style approximation, not
  validated against CIE colour-matching functions, and out-of-band colours are a
  convention with no physical referent. The module says so.
- **A pre-existing discontinuity is preserved, not fixed.** At the band edges the
  in-band roll-off bottoms out darker than the out-of-band start (780 nm →
  `(76,0,0)`, just past → `(140,5,5)`). That is legacy behaviour; changing it
  would mean touching the in-band curve this PR deliberately froze.

## Not addressed from #1

Items 2 (optical path length readout) and 3 (shutter element) remain open. This
PR addresses item 1 only, so #1 should stay open.
