### PR TITLE
Turn the inert bake "radius" into a width scale that works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Fixed — a bake control that never did anything
+- **"Beam radius" was inert and is now a working width scale.** The bake took a `radius`
+  argument, offered it in the redo panel and in `optics_api.bake_beams()`, and ignored it
+  for any segment carrying a Gaussian — which is every segment a source produces (measured:
+  0 of 171 traced segments across all 27 built-in examples lack one, because the source
+  floors its waist). Baking `michelson` at 0.6, 2.0 and 8.0 gave *exactly* equal tube
+  extents, raw floats, `max |delta| = 0.0`. Replaced by a scene setting, **Beam width
+  scale**, that multiplies the real w(z): the tube keeps tracking the physical beam and 1.0
+  is physical size, so a figure can have fatter beams without the render implying a wider
+  beam. The unreachable no-Gaussian branch keeps a fixed internal fallback instead of a
+  user-facing knob. It is in the bake signature too, so changing it re-bakes — the scale
+  moves nothing, and a signature blind to it would render the previous widths.
+  **Breaking:** `optics_api.bake_beams(radius=...)` and the MCP tool's `radius` are now
+  `scale`. Passing `radius` fails loudly rather than being silently ignored, which is what
+  it did before.
+
 ### Added — detector path statistics and a binary shutter
 - **Source-to-detector path readout.** `path_statistics()` reconstructs every parent-indexed arrival route and
   reports geometric length and the tracer's accumulated phase OPL. The same range is visible in Inspect →

--- a/mcp/optics_mcp_server.py
+++ b/mcp/optics_mcp_server.py
@@ -773,9 +773,11 @@ def check_mechanics() -> str:
 
 
 @mcp.tool()
-def bake_beams(radius: float = 0.6) -> str:
-    """Bake the traced beam path into emission-cylinder meshes (for rendering)."""
-    return _fmt(_call("bake_beams", radius=radius))
+def bake_beams(scale: float = 0.0) -> str:
+    """Bake the traced beam path into emission-cylinder meshes (for rendering). `scale`
+    multiplies the tube width (0 = use the scene's Beam width scale); the tube still follows
+    the real Gaussian w(z), so 1.0 is physical size."""
+    return _fmt(_call("bake_beams", **({"scale": scale} if scale > 0.0 else {})))
 
 
 @mcp.tool()

--- a/optical_alignment_sim/bake.py
+++ b/optical_alignment_sim/bake.py
@@ -17,17 +17,29 @@ from . import tracer, beamcolor
 BEAM_COLL = "COL_BEAMS"
 BEAM_MAT = "OPTICS_BEAM"
 
+# Tube radius for a segment that carries NO Gaussian q. Every source-originated ray does carry
+# one (the source floors its waist at 1 um, tracer.py), so this is a safety net, not a control:
+# the user-facing knob is the scene's beam_radius_scale, which multiplies the real w(z).
+FALLBACK_RADIUS_MM = 0.6
+
 _baked_sig = None       # signature of the segments currently baked (so renders never use a stale bake)
 
 
-def _segments_sig(segs, oob=None):
+def _scene_scale(scene):
+    return float(getattr(scene.optics, "beam_radius_scale", 1.0) or 1.0)
+
+
+def _segments_sig(segs, oob=None, scale=None):
     """Hash of everything the bake turns into meshes and materials.
 
     Endpoints are not enough. The tube's SHAPE also follows `kind` (a split-transmitted leg
     is drawn thinner) and the Gaussian taper (`w_mm`/`qd`/`m2`), and its COLOUR follows the
     wavelength and the invisible-beam mode. Signing geometry alone let `ensure_beams` keep a
     stale bake when only the colour had moved: retune a source's wavelength, or switch
-    oob_display, and the render still showed the previous tubes because nothing had moved."""
+    oob_display, and the render still showed the previous tubes because nothing had moved.
+
+    `scale` is in here for the same reason: it resizes every tube while moving nothing, so a
+    signature blind to it would render the previous widths."""
     rows = []
     for s in segs:
         rows.append((
@@ -36,7 +48,7 @@ def _segments_sig(segs, oob=None):
             round(s.get("w_mm") or 0.0, 6),
             tuple(round(v, 6) for v in (s.get("qd") or ())),
         ))
-    return hash((oob, tuple(rows)))
+    return hash((oob, round(float(scale), 6) if scale is not None else None, tuple(rows)))
 
 
 def beam_collection(scene):
@@ -156,20 +168,29 @@ def _make_taper(context, name, p1, p2, r1, r2, mat, coll):
     return ob
 
 
-def _vis_radius(w_mm, base, kind):
+def _vis_radius(w_mm, kind, scale=1.0):
     """VISIBLE tube radius tracking the REAL 1/e^2 Gaussian radius w(z) -- so the beam you SEE matches the
     footprint the physics actually samples (an expanded beam renders WIDE, covering the whole illuminated
     optic, not a thin stand-in). Floored at 0.3 mm so a focus / thin beam stays a visible neck; NO upper
     clamp, so a beam-expander's wide collimated output is shown at its true size (the old 6 mm cap made a
-    Ø20 mm beam look Ø12 mm -- visually under-illuminating an optic the sensor fully reads)."""
-    r = max(w_mm, 0.3) if (w_mm and w_mm > 0.0) else base
-    return r * (0.6 if kind == 'SPLIT_T' else 1.0)
+    Ø20 mm beam look Ø12 mm -- visually under-illuminating an optic the sensor fully reads).
+
+    `scale` multiplies the result: w(z) stays the truth, and a figure that needs fatter beams gets
+    them without pretending the beam is physically wider. FALLBACK_RADIUS_MM only covers a segment
+    that carries no Gaussian at all."""
+    r = max(w_mm, 0.3) if (w_mm and w_mm > 0.0) else FALLBACK_RADIUS_MM
+    return r * scale * (0.6 if kind == 'SPLIT_T' else 1.0)
 
 
-def bake_beams(context, radius=0.6):
+def bake_beams(context, scale=None):
+    """Bake the traced beams into meshes. `scale` multiplies every tube's radius (None = the
+    scene's beam_radius_scale). It is a display scale on the real w(z), not a radius in mm --
+    the old `radius` argument claimed to be one but never reached a Gaussian segment."""
     global _baked_sig
     from . import physics
     scene = context.scene
+    if scale is None:
+        scale = _scene_scale(scene)
     # always re-trace: baking the current geometry (not a possibly-stale cache from before the
     # last edit, e.g. with live mode off) is the whole point of a fresh bake
     tracer.cached_segments = tracer.trace_scene(
@@ -191,21 +212,21 @@ def bake_beams(context, radius=0.6):
             q2 = complex(qd[0], qd[1]); wl = s.get("wavelength", 633.0)
             m2 = s.get("m2", 1.0)                          # B1: physical radius = sqrt(m2)*beam_radius(q)
             L = (p2 - p1).length
-            r1 = _vis_radius(physics.beam_radius_m2(q2 - L, wl, m2), radius, s["kind"])   # w at p1
-            r2 = _vis_radius(s.get("w_mm") or physics.beam_radius_m2(q2, wl, m2), radius, s["kind"])  # w at p2
-        else:                                           # no Gaussian -> constant (thinner for SPLIT_T)
-            r1 = r2 = radius * (0.6 if s["kind"] == 'SPLIT_T' else 1.0)
+            r1 = _vis_radius(physics.beam_radius_m2(q2 - L, wl, m2), s["kind"], scale)   # w at p1
+            r2 = _vis_radius(s.get("w_mm") or physics.beam_radius_m2(q2, wl, m2), s["kind"], scale)  # w at p2
+        else:                                           # no Gaussian -> the fallback (thinner for SPLIT_T)
+            r1 = r2 = _vis_radius(0.0, s["kind"], scale)
         if _make_taper(context, "BEAM_%02d" % i, p1, p2, r1, r2, mat, coll):
             n += 1
-    _baked_sig = _segments_sig(tracer.cached_segments, oob)
+    _baked_sig = _segments_sig(tracer.cached_segments, oob, scale)
     return n
 
 
 def ensure_beams(context):
     """Make sure baked beams exist AND match what the current scene should draw, before a
     render. Re-bakes when anything the bake depends on has changed since the last one -- the
-    beam path, but also the wavelengths and the invisible-beam mode, which change the tubes'
-    colour without moving them (the old bake would otherwise render stale beams)."""
+    beam path, but also the wavelengths, the invisible-beam mode and the width scale, which
+    change the tubes without moving them (the old bake would otherwise render stale beams)."""
     scene = context.scene
     segs = tracer.trace_scene(scene, mode=scene.optics.trace_mode,
                               max_segments=scene.optics.max_segments, max_depth=scene.optics.max_depth)
@@ -213,7 +234,7 @@ def ensure_beams(context):
     c = bpy.data.collections.get(BEAM_COLL)
     have = c is not None and any(o.name.startswith("BEAM_") for o in c.objects)
     oob = getattr(scene.optics, "oob_display", 'FALSE_COLOR')
-    if have and _segments_sig(segs, oob) == _baked_sig:
+    if have and _segments_sig(segs, oob, _scene_scale(scene)) == _baked_sig:
         return len(c.objects)
     return bake_beams(context)
 
@@ -224,10 +245,14 @@ class OPTICS_OT_bake_beams(Operator):
     bl_description = "Create emission-cylinder meshes from the current beam path (for rendering)"
     bl_options = {'REGISTER', 'UNDO'}
 
-    radius: FloatProperty(name="Beam radius (mm)", default=0.6, min=0.01)
+    # A SCALE, not a radius in mm: the tube follows the real w(z), this widens it for a figure.
+    # Defaults to 0 meaning "use the scene setting", so the redo panel does not silently
+    # override beam_radius_scale every time the operator runs.
+    scale: FloatProperty(name="Width scale", default=0.0, min=0.0, max=20.0,
+                         description="Multiply the beam tube width (0 = use the scene's Beam width scale)")
 
     def execute(self, context):
-        n = bake_beams(context, radius=self.radius)
+        n = bake_beams(context, scale=(self.scale if self.scale > 0.0 else None))
         self.report({'INFO'}, "Baked %d beam segments into '%s'" % (n, BEAM_COLL))
         return {'FINISHED'}
 

--- a/optical_alignment_sim/optics_api.py
+++ b/optical_alignment_sim/optics_api.py
@@ -1533,8 +1533,13 @@ def set_param(name, key, value):
     return {"ok": True, "name": name, key: value}
 
 
-def bake_beams(radius=0.6):
-    return {"baked": _bake.bake_beams(bpy.context, radius=radius)}
+def bake_beams(scale=None):
+    """Bake the traced beams into renderable meshes. `scale` multiplies each tube's width
+    (None = the scene's Beam width scale). It is a display scale on the real Gaussian w(z),
+    not a radius in mm: the removed `radius` argument claimed to be one but never reached a
+    segment carrying a Gaussian, which is every segment a source produces."""
+    return {"baked": _bake.bake_beams(bpy.context, scale=scale),
+            "scale": _bake._scene_scale(_scene()) if scale is None else float(scale)}
 
 
 def clear_beams():

--- a/optical_alignment_sim/properties.py
+++ b/optical_alignment_sim/properties.py
@@ -775,6 +775,12 @@ class OpticalSceneProps(PropertyGroup):
     max_segments: IntProperty(default=64, min=1, max=1024)
     max_depth: IntProperty(default=12, min=1, max=64)
     line_width: FloatProperty(name="Beam width", default=3.0, min=0.5, max=10.0)
+    # The bake's counterpart to line_width. A SCALE on the real Gaussian w(z), not a radius:
+    # the tube keeps tracking the physical beam, this only makes it read better in a figure.
+    beam_radius_scale: FloatProperty(
+        name="Beam width scale", default=1.0, min=0.05, max=20.0,
+        description="Multiply the baked beam tube width. The tube still follows the real Gaussian "
+                    "w(z); this scales it for rendering, so 1.0 is physical size")
     show_ports: BoolProperty(name="Show ports", default=True)
     # How IR / UV beams are DRAWN (viewport, bake and SVG alike). Display only -- the trace is
     # untouched, so switching this never changes a power, a Jones vector or a segment count.

--- a/optical_alignment_sim/ui.py
+++ b/optical_alignment_sim/ui.py
@@ -396,6 +396,7 @@ class OPTICS_PT_trace_settings(_OpticsPanel, Panel):
             col = layout.column(align=True)
             col.prop(props, "line_width")
             col.prop(props, "show_ports")
+            col.prop(props, "beam_radius_scale")
             col.prop(props, "oob_display")
             col.prop(props, "auto_color")
             col.prop(props, "max_segments")

--- a/tests/_render_a9_ghost.py
+++ b/tests/_render_a9_ghost.py
@@ -79,7 +79,7 @@ def main():
 
     # bake the beams to emission tubes, then RE-COLOR the ghost legs dim/amber so the ~4% ghost reads
     # as clearly fainter than the primary (the bake uses one bright-red material for every segment).
-    bake.bake_beams(bpy.context, radius=0.9)
+    bake.bake_beams(bpy.context)
     segs = tracer.cached_segments
     # crank the PRIMARY beam emission so it reads bright red against the studio fill (the ghost stays dim)
     pmat = bpy.data.materials.get("OPTICS_BEAM")

--- a/tests/_render_c7_nlcrystal.py
+++ b/tests/_render_c7_nlcrystal.py
@@ -67,7 +67,7 @@ def main():
 
     # bake every beam to an emission tube, then recolor by WAVELENGTH so the render reads physically:
     # 1064 IR -> deep red, 532 SHG -> bright green.
-    bake.bake_beams(bpy.context, radius=0.9)
+    bake.bake_beams(bpy.context)
     segs = tracer.cached_segments
     ir_mat = _emission("C7_IR_BEAM", (1.0, 0.10, 0.05), 75.0)      # 1064 nm infrared (rendered deep red)
     green_mat = _emission("C7_GREEN_BEAM", (0.10, 1.0, 0.18), 160.0)  # 532 nm second harmonic (green)

--- a/tests/_render_coating_pickoff.py
+++ b/tests/_render_coating_pickoff.py
@@ -79,7 +79,7 @@ def main():
 
     # bake the beams to emission tubes, then RE-COLOR the pickoff arm dim/amber so the 30% pickoff reads
     # as clearly fainter than the 70% primary (the bake uses one bright-red material for every segment).
-    bake.bake_beams(bpy.context, radius=0.9)
+    bake.bake_beams(bpy.context)
     segs = tracer.cached_segments
     # the pickoff lineage = the REFLECT child whose `from` is the pickoff window, + its descendants.
     is_pick = [s.get("kind") == "REFLECT" and s.get("from") == "A11_Pickoff" for s in segs]

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2223,6 +2223,50 @@ bake.clear_baked(sc)
 check("HIDE bakes fewer beam tubes than FALSE_COLOR (the IR ones are dropped)",
       0 < _n_hidden < _n_shown)
 
+print("[bake width scale: a control that actually reaches the tubes]")
+# The old `radius` argument never reached a Gaussian segment -- and every segment a source
+# produces carries one -- so it was inert on every bench. beam_radius_scale multiplies the
+# real w(z) instead, which is the branch that actually runs.
+sc.optics.oob_display = 'FALSE_COLOR'
+
+
+def _tube_widths():
+    return [o.dimensions.x for o in
+            sorted((o for o in sc.objects if o.name.startswith("BEAM_")), key=lambda o: o.name)]
+
+
+sc.optics.beam_radius_scale = 1.0
+bake.bake_beams(bpy.context)
+_w1 = _tube_widths()
+sc.optics.beam_radius_scale = 3.0
+bake.bake_beams(bpy.context)
+_w3 = _tube_widths()
+check("beam_radius_scale actually resizes the baked tubes",
+      len(_w1) == len(_w3) and len(_w1) > 0 and all(b > a for a, b in zip(_w1, _w3)))
+check("...and it scales them proportionally (3x scale -> 3x width)",
+      all(abs(b - 3.0 * a) < 1e-4 for a, b in zip(_w1, _w3)),
+      str(list(zip(_w1[:3], _w3[:3]))))
+check("scale=1.0 is physical size (the tube still tracks the real w(z), floor 0.3 mm)",
+      all(w >= 2 * 0.3 - 1e-6 for w in _w1))
+
+# the scale moves nothing, so ensure_beams must still notice it -- the same class of bug as
+# the wavelength/mode staleness fixed earlier
+sc.optics.beam_radius_scale = 1.0
+bake.bake_beams(bpy.context)
+_before_scale = _tube_widths()
+sc.optics.beam_radius_scale = 2.5
+bake.ensure_beams(bpy.context)
+check("ensure_beams re-bakes on a SCALE change alone (nothing moved)",
+      all(abs(b - 2.5 * a) < 1e-4 for a, b in zip(_before_scale, _tube_widths())))
+check("the bake signature separates two scales that produce different tubes",
+      bake._segments_sig(tracer.cached_segments, 'FALSE_COLOR', 1.0)
+      != bake._segments_sig(tracer.cached_segments, 'FALSE_COLOR', 2.5))
+sc.optics.beam_radius_scale = 1.0
+bake.clear_baked(sc)
+bake.bake_beams(bpy.context)
+_n_shown = sum(1 for o in sc.objects if o.name.startswith("BEAM_"))
+bake.clear_baked(sc)
+
 # The render path is ensure_beams(), not bake_beams(): it SKIPS the re-bake when its signature
 # matches. A colour-only change moves NOTHING, so a signature over endpoints alone kept the
 # previous tubes and rendered stale colour. Both cases below hold the geometry fixed on purpose

--- a/tools/render_optomech_showcase.py
+++ b/tools/render_optomech_showcase.py
@@ -109,7 +109,7 @@ def main():
     if bad or issues:
         raise RuntimeError("showcase gate failed: bad=%d validate=%s" % (bad, issues))
 
-    bake.bake_beams(bpy.context, radius=1.1)
+    bake.bake_beams(bpy.context)
     render.setup_final(scene)
     scene.cycles.device = 'CPU'
     scene.cycles.samples = 96


### PR DESCRIPTION
The bake took a `radius` argument, offered it in the redo panel and in `optics_api.bake_beams()`, and ignored it.

`_vis_radius` only falls back to it when a segment carries no Gaussian, and every segment a source produces carries one — the source floors its waist, so `q` is never None. Measured: **0 of 171** traced segments across all 27 built-in examples lack a Gaussian, and baking `michelson` at radius 0.6, 2.0 and 8.0 produced **exactly equal** tube extents as raw floats, `max |delta| = 0.0`.

A control that silently does nothing is worse than no control: it invites a user to fix thin-looking beams by raising it, and an agent gets a success return from a parameter that was dropped.

## What replaces it

A scene setting, **Beam width scale** (`beam_radius_scale`), that multiplies the real w(z). The tube still tracks the physical beam, 1.0 is physical size, and a figure that needs fatter beams gets them without the render implying a wider beam. It sits next to `line_width` — the viewport's equivalent, which has always worked. That asymmetry is what made the dead knob easy to miss.

The unreachable no-Gaussian branch keeps a fixed internal constant instead of a user-facing knob.

The scale is in the bake signature, for the same reason wavelength and the display mode are: it resizes every tube while moving nothing, so `ensure_beams` with a signature blind to it would render the previous widths.

## Breaking

`optics_api.bake_beams(radius=...)` and the MCP tool's `radius` are now `scale`. Passing `radius` now fails loudly instead of being silently ignored. The four in-repo figure tools passed `radius=0.9/1.1`; since those were inert, dropping the argument leaves their output unchanged.

## Verification

Verified by negative control, not just by passing: blinding the signature to `scale` drops the suite to **504/506** with exactly the two cache checks failing.

- `test_optics` **506/506** (was 501; +5 new checks)
- `test_validation` **320/320**
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- `pathstats`, `beamcolor`, `physics` bare self-tests pass
- `check_release_consistency` PASS, `git diff --check` clean

Measured behaviour: `scale=3.0` widens every tube by exactly 3x (`|delta| < 1e-4`); `scale=1.0` preserves the 0.3 mm floor.

## Not verified

No UI interaction was exercised — the property and panel row were reviewed as code, and the underlying paths are tested headlessly.