### PR TITLE
Release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **Blender Optics Simulator** (`optical_alignment_sim`
 here. The format follows [Keep a Changelog](https://keepachangelog.com/), and the project uses
 semantic versioning.
 
-## [Unreleased]
+## [0.28.0] — One colour convention, a path readout that admits its limits, and a shutter — 2026-08-11
 
 ### Fixed — a bake control that never did anything
 - **"Beam radius" was inert and is now a working width scale.** The bake took a `radius`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
   - gaussian-beam
   - polarization
   - mcp
-version: "0.27.0"
-date-released: "2026-07-28"
+version: "0.28.0"
+date-released: "2026-08-11"
 doi: "10.5281/zenodo.20778997"
 identifiers:
   - type: doi

--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ ready-to-paste APA / BibTeX.
   author  = {Çobanoğlu, Muhammet Emir},
   title   = {Blender Optics Simulator},
   year    = {2026},
-  version = {0.27.0},
+  version = {0.28.0},
   doi     = {10.5281/zenodo.20778997},
   license = {GPL-3.0-or-later},
   url     = {https://github.com/emircbngl/blender-optics-simulator}

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,10 +25,10 @@
 <body>
 <div class="wrap">
   <h1>Blender Optics Simulator</h1>
-  <p class="tag">Live ray tracing &amp; auto-alignment for optical benches · v0.27.0</p>
+  <p class="tag">Live ray tracing &amp; auto-alignment for optical benches · v0.28.0</p>
 
   <p><b>One-click install (Blender 4.2+):</b></p>
-  <p><a class="cta" href="https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.27.0/optical_alignment_sim-0.27.0.zip?repository=https%3A%2F%2Femircbngl.github.io%2Fblender-optics-simulator%2Findex.json&blender_version_min=4.2.0">⤓ Drag this into Blender to install</a></p>
+  <p><a class="cta" href="https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.28.0/optical_alignment_sim-0.28.0.zip?repository=https%3A%2F%2Femircbngl.github.io%2Fblender-optics-simulator%2Findex.json&blender_version_min=4.2.0">⤓ Drag this into Blender to install</a></p>
   <p class="hint">Drag the button onto an open Blender window. Blender installs the add-on
      <b>and</b> subscribes you to update notifications — no URL to type. Make sure
      <b>Edit ▸ Preferences ▸ System ▸ Network ▸ Allow Online Access</b> is on.</p>

--- a/docs/index.json
+++ b/docs/index.json
@@ -7,7 +7,7 @@
    "id": "optical_alignment_sim",
    "name": "Optics Simulator",
    "tagline": "Live ray tracing & auto-alignment for optical benches",
-   "version": "0.27.0",
+   "version": "0.28.0",
    "type": "add-on",
    "maintainer": "Emir <emircbngl@gmail.com>",
    "license": [
@@ -22,9 +22,9 @@
    "tags": [
     "Render"
    ],
-   "archive_url": "https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.27.0/optical_alignment_sim-0.27.0.zip",
-   "archive_size": 437618,
-   "archive_hash": "sha256:ce1d19fc4fd4812057dee747c84900e490b75eabeec6566c3bdb18f91adf3e51"
+   "archive_url": "https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.28.0/optical_alignment_sim-0.28.0.zip",
+   "archive_size": 449348,
+   "archive_hash": "sha256:61ecd70adbfa0c7e3a8700bf3810cf510d9c31970094b77f84d898d31cd7cd16"
   }
  ]
 }

--- a/optical_alignment_sim/blender_manifest.toml
+++ b/optical_alignment_sim/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "optical_alignment_sim"
-version = "0.27.0"
+version = "0.28.0"
 name = "Optics Simulator"
 tagline = "Live ray tracing & auto-alignment for optical benches"
 maintainer = "Emir <emircbngl@gmail.com>"


### PR DESCRIPTION
Cuts the release for the three changes merged since 0.27.0: #2, #3 and #4.

## Version

**Minor, not patch.** Alongside the new features there is a breaking API change: `optics_api.bake_beams()` and the MCP tool take `scale` where they took `radius`.

Bumped in the six places that declare it — `blender_manifest.toml`, `CITATION.cff` (version + date-released), `CHANGELOG.md`, `docs/index.json`, `docs/index.html`, `README.md`'s BibTeX — plus the pages-repo `archive_size` and `archive_hash` for the v0.28.0 asset.

`tools/check_release_consistency.py`: **PASS** (pre mode, 0.28.0).

## What ships

- **#2** — one beam-colour convention across viewport, bake and SVG; the viewport honours wavelength for the first time; IR/UV ramp instead of collapsing to one colour; `oob_display` scene setting (false colour / hide / vivid).
- **#3** — `path_statistics()` reports every detector arrival's route, geometric length and phase OPL, and says `group_delay_available: false` rather than letting the number read as an ultrafast time-of-flight; a real `SHUTTER` element type; custom-component guidance in the README.
- **#4** — the bake's `radius` control was inert on every bench (0 of 171 traced segments across all 27 built-in examples lack a Gaussian); replaced by `beam_radius_scale`, which multiplies the real w(z).

## Release asset

`optical_alignment_sim-0.28.0.zip` — 46 entries (45 `.py` + `blender_manifest.toml`, flat), 449348 bytes, `sha256:61ecd70adbfa0c7e3a8700bf3810cf510d9c31970094b77f84d898d31cd7cd16`. Same shape as the v0.27.0 asset, which had 44 entries.

## Still outstanding after this merges

`CITATION.cff` has no `Version DOI for v0.28.0` identifier yet. Zenodo mints it once the GitHub release exists, so it lands in a follow-up commit — the release-consistency `--post` check treats it as informational pre-release.