### PR TITLE
Say what the alignment demo actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ can *see* and *close the loop* on.
 <p align="center"><em><b>A real bench, traced live.</b> Every mount, post, base and beam above is placed and computed by the add-on — then rendered in Cycles. Build it by hand in the UI, from a script, or let an AI agent drive it over MCP.</em></p>
 
 <p align="center">
-  <img src="docs/img/agent-align.gif" width="88%" alt="A laser beam steered by a kinematic mirror misses the detector, then auto-alignment walks the mount until the beam locks onto the sensor — rendered live in Blender">
+  <img src="docs/img/agent-align.gif" width="88%" alt="A laser beam steered by a kinematic mirror lands well off the detector centre, then auto-alignment walks the mount until the beam is re-centred on the sensor — rendered live in Blender">
 </p>
 
-<p align="center"><em><b>Alignment, solved.</b> A kinematic mirror is knocked out of alignment, so the beam misses the detector — then one <code>optics_api.align_element()</code> call solves the pointing residual (7.0 → 0.001 mrad) and the beam locks onto the sensor. See <a href="examples/agent_align.py"><code>examples/agent_align.py</code></a>.</em></p>
+<p align="center"><em><b>Alignment, solved.</b> A kinematic mirror is knocked 2° out of alignment, throwing the beam well off the sensor centre — then one <code>optics_api.align_element()</code> call collapses the pointing residual (7.02 → 0.0008 mrad) and re-centres it. See <a href="examples/agent_align.py"><code>examples/agent_align.py</code></a>, which reproduces those numbers headlessly in one command.</em></p>
 
 ---
 


### PR DESCRIPTION
Found while fact-checking the launch copy against the repo.

The hero caption and the GIF alt text both said the beam **"misses the detector"** and then **"locks onto the sensor"**. Running the example they link to says otherwise:

```
misaligned  -> beam on the camera? True
align_element('AA_Mirror') -> before 7.021570, after 0.000761
realigned   -> beam on the camera? True
```

The beam is on the sensor in *both* states. `examples/agent_align.py` is candid about this in its own comments — *"the beam still grazes the sensor but is well off centre, within the auto-aligner's capture range"* — so the README was claiming more than the example it points at. Checking frames 0 and 44 of `agent-align.gif`, it shows the same off-centre → re-centred motion, not a recovered miss.

The residual numbers were fine, just rounded: measured 7.0216 → 0.00076 mrad.

Caption now describes the real behaviour, uses the measured values, and notes that the example reproduces them headlessly in one command — which matters, because this is the number most likely to be quoted and re-run by anyone who reads a launch post.