### PR TITLE
Stop shipping one machine's mesh folder as the default

### DIFF
--- a/optical_alignment_sim/prefs.py
+++ b/optical_alignment_sim/prefs.py
@@ -25,8 +25,14 @@ def _auto_freecad():
 
 
 def _default_mesh_dir():
-    d = os.path.expanduser("~/Documents/Claude Projects/3D şema/blender_workspace/stl")
-    return d if os.path.isdir(d) else ""
+    """Vendor meshes are not bundled, so there is no location we can sensibly guess.
+
+    Honour ``OPTICS_MESH_DIR`` when it points at a real folder — that keeps a
+    one-machine convenience out of the source — and otherwise leave the field blank
+    for the user to fill in from the add-on preferences.
+    """
+    d = os.environ.get("OPTICS_MESH_DIR", "")
+    return d if d and os.path.isdir(d) else ""
 
 
 class OpticsAddonPrefs(AddonPreferences):


### PR DESCRIPTION
Found while sweeping the tree for hardcoded paths before launch.

`prefs.py` set the default for the **Component mesh folder** preference from the author's own directory layout:

```python
d = os.path.expanduser("~/Documents/Claude Projects/3D şema/blender_workspace/stl")
return d if os.path.isdir(d) else ""
```

Nothing was broken by it — the directory does not exist on anyone else's machine, so it returned `""` and the field came up blank, which is the right behaviour. But the path was sitting in published source, carrying a private folder structure with it.

Now reads `OPTICS_MESH_DIR`, falling back to `""` exactly as before:

```
OPTICS_MESH_DIR=/tmp      -> '/tmp'
OPTICS_MESH_DIR=/nope/... -> ''
unset                     -> ''
```

Identical behaviour for everyone who is not the author; the author keeps the convenience by exporting one variable.

**One dependency worth noting:** `tools/build_platform_zip.py:124` patches this file textually and uses `(?=def _default_mesh_dir)` as its lookahead boundary when stripping `_auto_freecad()`. That `def` line is untouched — verified the regex still matches after the change. `physics.py` and `beamcolor.py` selftests pass.

Unrelated to #6, which fixes the alignment caption.