### PR TITLE
Correct two docs that no longer describe the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,13 @@ python3 tools/job.py run optics -- blender --background --factory-startup \
 python3 tools/job.py wait optics
 ```
 
-`tests/test_optics.py` alone is ~2900 lines and 403 checks; it exits with the
-number of failures. `test_validation.py` and `test_mesh_health.py` run the same
-way. Everything named `tests/_verify_*.py`, `_plot_*.py`, `_render_*.py` is a
-manual tool, not part of CI — do not treat those as the test suite.
+`tests/test_optics.py` is by far the largest suite — a few thousand lines and
+several hundred checks — and it exits with the *number of failures*, so read the
+`REGRESSION PASS (n/n checks)` line rather than trusting a count quoted here: it
+moves with every PR, and a stale number in this file has already gone unnoticed
+once. `test_validation.py` and `test_mesh_health.py` run the same way.
+Everything named `tests/_verify_*.py`, `_plot_*.py`, `_render_*.py` is a manual
+tool, not part of CI — do not treat those as the test suite.
 
 Before proposing a release, run the repo's own gate:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,10 @@ ideas, physics validation, documentation, and code.
    ```
 3. `tests/test_validation.py` = closed-form / oracle-verified physics checks.
    `tests/test_optics.py` = the byte-identical regression + pipeline invariants.
-4. CI runs both on Blender 4.2.3 (the `blender_version_min`) and 5.x. Both must stay green.
+4. CI runs on Blender 4.2.3 — the `blender_version_min`, and the only version it runs. It must stay
+   green. The add-on supports 4.2+ including 5.x, but **no CI job covers 5.x**, so a 5.x-only
+   regression can reach `main`: if your change touches anything version-sensitive, run the suites on
+   a 5.x build locally and say so in the PR.
 
 ## Submitting a change
 


### PR DESCRIPTION
Same class as #8: published text asserting something that is not true.

## `CONTRIBUTING.md` — a CI gate that does not exist

> 4. CI runs both on Blender 4.2.3 (the `blender_version_min`) and 5.x. Both must stay green.

`ci.yml` pins `BLENDER_VERSION: "4.2.3"` in **both** jobs (lines 12 and 81) and defines no matrix. 5.x has never been a CI gate.

As a contributor instruction it was unsatisfiable — you cannot keep green a job that does not exist — and it hid a real gap: **a 5.x-only regression can reach `main`.** The text now says what CI actually covers, names the gap, and asks contributors touching version-sensitive code to run the suites on a 5.x build locally and report it in the PR.

## `AGENTS.md` — a hardcoded check count, badly stale

> `tests/test_optics.py` alone is ~2900 lines and 403 checks

Actually 3131 lines and **506** checks (confirmed by the last CI run on `main`). An agent that trusts a hardcoded count reads a passing run as a failure, or the reverse.

Rather than refresh a number that goes stale on the next PR — it moved 480 → 493 → 501 → 506 during this month alone — it now points at the `REGRESSION PASS (n/n checks)` line and says why a quoted count cannot be trusted.

## Not decided here

Whether to actually add 5.x to the CI matrix is a separate call: it doubles the job and may surface real failures. This PR only makes the documentation honest about today. Happy to open that as its own issue if you want the matrix.

## Scope

Docs only — no code, no behaviour, no version change. `check_release_consistency` PASS, `git diff --check` clean.