### PR TITLE
Run CI on 5.x, not just the minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,17 @@ on:
 
 jobs:
   test:
+    # Both ends of the supported range. 4.2.3 is blender_version_min and stays the gate for
+    # "does it still run on the oldest build"; 5.1.1 covers the top, which ships a 5.x-specific
+    # artifact (build_platform_zip bundles cp313 wheels for it) that no job had ever exercised on
+    # 5.x. fail-fast off: a break at one end must not hide the state of the other.
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        blender: ["4.2.3", "5.1.1"]
     env:
-      BLENDER_VERSION: "4.2.3"
+      BLENDER_VERSION: ${{ matrix.blender }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true     # opt the checkout/cache actions onto Node 24
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #12.

`ci.yml` pinned `BLENDER_VERSION: "4.2.3"` in both jobs and defined no matrix, so the top of the supported range was never exercised.

That was not a hypothetical gap: `tools/build_platform_zip.py:9` bundles **cp313 wheels specifically for 5.x**, and the artifact we ship for that Python had never been run on it. `CONTRIBUTING.md:50-54` already guards the other direction — `bpy` APIs must be checked against `blender_version_min` — and nothing guarded the top, so an API removed or renamed in 5.x would pass CI and break on the platform the cp313 wheels target.

## The change

```yaml
    strategy:
      fail-fast: false
      matrix:
        blender: ["4.2.3", "5.1.1"]
    env:
      BLENDER_VERSION: ${{ matrix.blender }}
```

Nine lines. The `test` job now covers the three suites **and `extension validate`** on both ends. `fail-fast: false` so a break at one end does not hide the state of the other. The existing cache key is already per-version (`blender-${{ env.BLENDER_VERSION }}-linux-x64`), so the second leg adds one cache entry and no cache logic.

## Decisions, so they are not silent

**The three Blender-independent steps now run twice** — physics self-test, release-metadata check, `--audit-only` store audit. They take seconds. A conditional to skip them is one more thing to get wrong than it is worth.

**`store-build` stays on 4.2.3 by choice, not oversight.** It runs `extension build --split-platforms`, and building the shipped zip with the *minimum* supported Blender is the conservative direction — the same zip installs on both. Its `validate` half is now covered on 5.x by the test job. That was open question 2 in #12; this is the answer, and if you want the build half matrixed too it is worth its own issue.

**5.1.1 pinned exactly**, matching how 4.2.3 is handled — reproducible runs, at the cost of a manual bump when 5.2 lands. That was open question 1.

## Verified before pushing, not by watching CI go red

- both download URLs the workflow constructs return **HTTP 200** (`Blender4.2/blender-4.2.3-linux-x64.tar.xz`, `Blender5.1/blender-5.1.1-linux-x64.tar.xz`)
- the YAML parses, with the matrix wired through to `BLENDER_VERSION`
- on **Blender 5.1.1** locally at this commit: regression **506/506**, validation **320/320**, mesh health **30 element meshes + 311 mount parts**, and `extension validate` succeeds
- `main` has no branch protection, so renaming the check to `test (4.2.3)` / `test (5.1.1)` breaks no required-status rule

This PR is where the 5.x leg proves itself: if it is red, the gap was real.