### PR TITLE
Say when the scene's unit scale does not match the add-on's

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ Ports**. Advanced mode lets you pick/edit the IN/OUT/REFLECT faces. The API equi
 retaining its ports and optical behaviour. Mesh appearance and optical behaviour are intentionally separate:
 new behaviour beyond the shipped element types still requires a tracer implementation, not only a mesh.
 
+### Units: 1 Blender unit = 1 mm
+
+Every component is built at that scale, and the whole measurement layer reads world coordinates **as
+millimetres** — `scale_length` is not consulted by the tracer, solvers, alignment or diagnostics. It is a
+convention, not a display preference: the same bench traced in a metre-scale scene produces a
+byte-identical trace, because the numbers are simply reinterpreted by Blender's UI while the physics still
+calls them millimetres.
+
+So work with **Scene → Units → Unit Scale = 0.001**. The examples set it for you (and say so when they
+change it). If you keep your own models at metre scale, bring them *to* the optics — scale them by 1000 on
+the way in — rather than rescaling the optics: an optic scaled to 0.001× would desynchronise from the
+physics, since a 150 mm arm would become 0.15 units and the tracer would read it as 0.15 mm.
+
+The add-on does not guess. Add a component in a scene on another unit scale and it is still placed at its
+true millimetre size, with a warning naming the factor — `add_component()` returns a `warning` key and the
+UI reports it. Supporting non-mm scenes properly means making the measurement layer unit-aware; that is
+tracked separately.
+
 ---
 
 ## What you can do

--- a/optical_alignment_sim/examples_builtin.py
+++ b/optical_alignment_sim/examples_builtin.py
@@ -678,11 +678,18 @@ def build(kind, context):
 def _show(context, coll_name):
     """Trace, enable the live overlay, frame the viewport on the new setup, and
     set a render camera (without forcing the viewport into camera view)."""
-    from . import tracer, render
+    from . import tracer, render, geometry
     sc = context.scene
+    # The examples are authored at 1 unit = 1 mm and the tracer measures in mm, so the scene has
+    # to be on that convention for the bench to read correctly. Forcing it is right; doing it
+    # silently was not -- a user who had set metres lost that setting with no message. Report it.
+    was = (sc.unit_settings.scale_length, sc.unit_settings.length_unit)
     sc.unit_settings.system = 'METRIC'
-    sc.unit_settings.scale_length = 0.001          # 1 unit = 1 mm (add-on convention)
+    sc.unit_settings.scale_length = geometry.ADDON_SCALE_LENGTH   # 1 unit = 1 mm (add-on convention)
     sc.unit_settings.length_unit = 'MILLIMETERS'
+    now = (sc.unit_settings.scale_length, sc.unit_settings.length_unit)
+    unit_note = ("scene units changed from %g/%s to mm — the examples and the tracer both "
+                 "measure in millimetres" % (was[0], was[1])) if was != now else None
     sc.optics.line_width = 4.0
     tracer.cached_segments = tracer.trace_scene(
         sc, mode=sc.optics.trace_mode,
@@ -713,6 +720,7 @@ def _show(context, coll_name):
                 ar.tag_redraw()
     except Exception:
         pass
+    return unit_note
 
 
 class OPTICS_OT_build_example(Operator):
@@ -735,10 +743,13 @@ class OPTICS_OT_build_example(Operator):
 
     def execute(self, context):
         name = build(self.kind, context)
-        _show(context, name)
+        unit_note = _show(context, name)
         from . import tracer
-        self.report({'INFO'}, "Built %s (%d beam segments)"
-                    % (EXAMPLES[self.kind][0], len(tracer.cached_segments)))
+        built = "Built %s (%d beam segments)" % (EXAMPLES[self.kind][0], len(tracer.cached_segments))
+        if unit_note:                      # never change a user's scene settings without saying so
+            self.report({'WARNING'}, "%s — %s" % (built, unit_note))
+        else:
+            self.report({'INFO'}, built)
         return {'FINISHED'}
 
 

--- a/optical_alignment_sim/geometry.py
+++ b/optical_alignment_sim/geometry.py
@@ -20,6 +20,35 @@ from mathutils import Vector
 
 EPS = 1e-6
 
+# --- unit convention --------------------------------------------------------
+# The whole measurement layer reads world coordinates AS MILLIMETRES. That is not a display
+# preference: `scale_length` is consulted nowhere in tracer / solvers / alignment /
+# diagnostics, so a bench traced at scale_length=1.0 yields a byte-identical trace to the
+# same bench at 0.001 -- the numbers are simply reinterpreted as metres by Blender's UI
+# while the physics still calls them millimetres.
+#
+# The consequence is silent and large: a 1" optic is 25.4 units wide, which reads as 25.4 m
+# in a metre-scale scene. Rescaling the OBJECT would desynchronise it from the physics (a
+# 150 mm arm becomes 0.15 units -> the tracer reads 0.15 mm), so the add-on does not guess.
+# It detects the mismatch and says so.
+ADDON_SCALE_LENGTH = 0.001          # 1 Blender unit == 1 mm
+
+
+def unit_scale_mismatch(scene):
+    """None when the scene matches the add-on's mm convention, else a one-line explanation.
+
+    Callers that place geometry should surface this rather than silently dropping a 25 m
+    lens into a metre-scale scene."""
+    sl = getattr(getattr(scene, "unit_settings", None), "scale_length", ADDON_SCALE_LENGTH)
+    if sl is None or abs(sl - ADDON_SCALE_LENGTH) <= 1e-9:
+        return None
+    factor = sl / ADDON_SCALE_LENGTH
+    return ("scene unit scale is %g, but this add-on measures in millimetres (scale_length %g). "
+            "Components are built at 1 unit = 1 mm, so they read %gx too large here, and the "
+            "trace still treats every distance as mm. Set Scene > Units > Unit Scale to %g and "
+            "scale your own models by %g on the way in."
+            % (sl, ADDON_SCALE_LENGTH, factor, ADDON_SCALE_LENGTH, factor))
+
 # --- axis helpers -----------------------------------------------------------
 
 # face/axis label -> (component index, sign)

--- a/optical_alignment_sim/library.py
+++ b/optical_alignment_sim/library.py
@@ -21,7 +21,7 @@ import bpy
 from bpy.types import Operator
 from bpy.props import StringProperty, EnumProperty, BoolProperty
 
-from . import presets, mounts
+from . import presets, mounts, geometry
 from . import operators as _ops
 from .prefs import get_prefs
 
@@ -435,7 +435,13 @@ class OPTICS_OT_add_from_library(Operator):
         if obj is None:
             self.report({'WARNING'}, msg)
             return {'CANCELLED'}
-        self.report({'INFO'}, "Added %s (%d ports)" % (obj.name, len(obj.optics.ports)))
+        # A component is built at 1 unit = 1 mm. In a scene on another unit scale it lands
+        # visibly wrong, and the old behaviour was to say nothing at all about why.
+        mismatch = geometry.unit_scale_mismatch(context.scene)
+        if mismatch:
+            self.report({'WARNING'}, "Added %s, but %s" % (obj.name, mismatch))
+        else:
+            self.report({'INFO'}, "Added %s (%d ports)" % (obj.name, len(obj.optics.ports)))
         return {'FINISHED'}
 
 

--- a/optical_alignment_sim/optics_api.py
+++ b/optical_alignment_sim/optics_api.py
@@ -1584,7 +1584,11 @@ def build_example(kind='mach_zehnder'):
         return {"error": "unknown example '%s'; choose from %s" % (kind, list(ex.EXAMPLES))}
     name = ex.build(kind, bpy.context)
     res = trace_beam()
-    return {"built": kind, "collection": name, "segments": res["segments"]}
+    out = {"built": kind, "collection": name, "segments": res["segments"]}
+    mismatch = geometry.unit_scale_mismatch(_scene())
+    if mismatch:                                # the bench is mm-authored; say so, do not rescale it
+        out["warning"] = mismatch
+    return out
 
 
 def build_bench(spec):
@@ -1601,12 +1605,20 @@ def build_bench(spec):
 
 
 def add_component(key, location=(0.0, 0.0, 0.0)):
-    """Spawn a catalog component by key (or its generic mesh-free fallback). {name, msg}."""
+    """Spawn a catalog component by key (or its generic mesh-free fallback). {name, msg}.
+
+    Components are built at 1 unit = 1 mm. When the scene is on another unit scale the result
+    carries a `warning`: the part is placed, but it reads the wrong size while the trace still
+    measures in mm, and an agent handed a bare success would have no way to know."""
     from . import library
     obj, msg = library.add_component(key, tuple(location))
     if obj is None:                             # unknown key -> a real error, not a {name: None} success
         return {"error": msg}
-    return {"name": obj.name, "msg": msg}
+    out = {"name": obj.name, "msg": msg}
+    mismatch = geometry.unit_scale_mismatch(_scene())
+    if mismatch:
+        out["warning"] = mismatch
+    return out
 
 
 def swap_part(name, filepath, refit_ports=False):

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2168,6 +2168,47 @@ bake.clear_baked(sc)
 check("no BEAM_ objects after clear", not any(o.name.startswith("BEAM_") for o in sc.objects))
 check("clear_baked frees beam meshes (no orphan leak)", len(bpy.data.meshes) <= m0)
 
+print("[unit-scale mismatch is reported, never silently absorbed]")
+from optical_alignment_sim import geometry as _geo
+check("the add-on's convention is 1 unit = 1 mm", _geo.ADDON_SCALE_LENGTH == 0.001)
+
+
+class _FakeUnits:
+    def __init__(self, sl):
+        self.scale_length = sl
+
+
+class _FakeScene:
+    def __init__(self, sl):
+        self.unit_settings = _FakeUnits(sl)
+
+
+check("a mm scene reports no mismatch", _geo.unit_scale_mismatch(_FakeScene(0.001)) is None)
+_um = _geo.unit_scale_mismatch(_FakeScene(1.0))
+check("a metre scene reports one, naming the factor and the fix",
+      isinstance(_um, str) and "1000" in _um and "0.001" in _um, str(_um))
+
+# the API surface an agent sees: a placed component must not look like a bare success
+_us_prev = sc.unit_settings.scale_length
+sc.unit_settings.scale_length = 0.001
+_ok = optics_api.add_component("SHUTTER", location=(0, 0, 0))
+check("add_component carries NO warning when the scene matches", "warning" not in _ok, str(_ok))
+_ok_obj = bpy.data.objects.get(_ok.get("name", ""))
+if _ok_obj is not None:
+    eg.drop_example_object(_ok_obj)
+sc.unit_settings.scale_length = 1.0
+_bad = optics_api.add_component("SHUTTER", location=(0, 0, 0))
+check("add_component warns when the scene is on another unit scale",
+      "warning" in _bad and "millimetres" in _bad["warning"] and _bad.get("name"), str(_bad))
+_bad_obj = bpy.data.objects.get(_bad.get("name", ""))
+_bad_dim = _bad_obj.dimensions.x if _bad_obj is not None else None
+# the part is still built at its mm size -- the add-on reports, it does not silently rescale
+check("the component is still built at 1 unit = 1 mm (no silent rescale)",
+      _bad_dim is not None and _bad_dim > 5.0, str(_bad_dim))
+if _bad_obj is not None:
+    eg.drop_example_object(_bad_obj)
+sc.unit_settings.scale_length = _us_prev
+
 print("[invisible-beam display mode: one colour convention, DISPLAY-only (trace untouched)]")
 from optical_alignment_sim import beamcolor, svg_export, overlay
 # the green doubler carries 1064 nm in and 532 nm out -- the case the mode exists for


### PR DESCRIPTION
Addresses the reported half of #9. **#9 stays open** for the other half — see below.

## What was silent

Components are built at 1 unit = 1 mm, and the measurement layer reads world coordinates as millimetres unconditionally: `scale_length` is consulted nowhere in tracer / solvers / alignment / diagnostics.

Measured — the same bench traced at both unit scales:

```
scale_length=0.001  segments=9  first opl=130.0000  last opl=640.0000
scale_length=1.0    segments=9  first opl=130.0000  last opl=640.0000
--> trace identical across unit scales: True
```

And a 1" lens is 25.4 units wide in both scenes, object scale (1,1,1) — which reads as **25.4 m** in a metre scene. The reporter was rescaling every imported part by hand with nothing in the add-on telling them why.

## What this does *not* do

It still does not rescale anything. Rescaling the **object** is the tempting fix and it is wrong: a 150 mm arm in a metre scene becomes 0.15 units, the tracer reads 0.15 mm, and every propagation, path length and aperture clip is off by 1000× **with no error raised**. Silent wrong numbers are worse than a part you resize yourself.

## What it does

`geometry.unit_scale_mismatch()` returns `None` or one line naming the factor and the fix. bpy-free, so it is testable on a duck-typed scene.

- `add_component()` and `build_example()` carry it as a **`warning`** key. An agent used to get a bare success from a call that placed a 25 m lens.
- The UI operator reports it as a `WARNING` instead of the usual `INFO`.
- **Related small bug:** building an example from the panel forced the scene to mm *silently*, so a user who had set metres lost that setting with no message. Forcing it is right — the examples and the tracer both need mm — but it now reports what it changed. (The API path never did this and still does not.)
- README gains a **Units** section: the convention, why rescaling the optics is the wrong direction, and what to do instead.

## Why #9 stays open

Working natively in a non-mm scene needs the measurement layer to be unit-aware, and **there is no chokepoint to convert at**. World geometry is read in ~128 places across tracer, solvers, alignment, diagnostics, scan and the opto-mechanics modules — the tracer reads `matrix_world` directly in 21 of them, not through `geometry.py`. Missing one gives a silent 1000× error in a physics simulator. That is a project, not a patch, and it belongs in the layer `CONTRIBUTING.md` guards with the byte-identical rule.

## Verification

**Negative control**, not just a passing run: with detection disabled the suite drops to **510/512** with exactly the two detection checks failing — and the failing detail is the old bare success, `{'name': 'SHUTTER_generic.001', 'msg': 'ok (generic)'}`.

- `test_optics` **512/512** (was 506; +6 new checks)
- `test_validation` **320/320**
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- `check_release_consistency` PASS, `git diff --check` clean

## Not verified

No UI interaction was exercised — the operator report paths were reviewed as code; the API paths they wrap are tested headlessly.