### PR TITLE
Give the aperture a shape, so a square optic stops clipping like a circle

### DIFF
--- a/optical_alignment_sim/optics_api.py
+++ b/optical_alignment_sim/optics_api.py
@@ -2155,7 +2155,7 @@ _PARAMS_BY_TYPE = {
     'WAVEPLATE': ["retardance_deg", "fast_axis_deg", "design_wl", "waveplate_crystal", "waveplate_order"],
     'POLARIZER': ["pol_axis_deg", "polarizer_type"],
     'SHUTTER': ["shutter_open", "clear_aperture"],
-    'APERTURE': ["clear_aperture"],
+    'APERTURE': ["clear_aperture", "aperture_shape", "aperture_half_y"],
     'PRISM': ["refractive_index", "prism_design_wl", "split_angle_deg"],
     'CRYSTAL': ["nl_process", "nl_efficiency", "poling_period_um", "nl_walkoff_mm"],
     'DETECTOR': ["clear_aperture", "analyzer"],

--- a/optical_alignment_sim/physics.py
+++ b/optical_alignment_sim/physics.py
@@ -1595,6 +1595,38 @@ def slit_transmission(b_mm, w_mm):
     return math.erf(math.sqrt(2.0) * b_mm / w_mm)
 
 
+def rect_aperture_transmission(a_mm, b_mm, w_mm):
+    """Power transmission of a RECTANGULAR clear aperture (half-widths ``a_mm`` x ``b_mm``) clipping a
+    circular Gaussian of 1/e^2 intensity radius ``w_mm``:
+
+        T = erf(sqrt2 * a/w) * erf(sqrt2 * b/w)   = slit_transmission(a,w) * slit_transmission(b,w)
+
+    NOT a new formula. A circular Gaussian I(x,y) ~ exp(-2(x^2+y^2)/w^2) is separable, so the rectangle
+    is exactly the product of the two 1-D slit clips, and that 1-D kernel is the VERIFIED one above
+    (physics_verify ok=true 8/8). Checked against direct 2-D numerical integration in
+    tests/test_validation.py, alongside the geometric bracket that a square of half-width a must pass
+    MORE than its inscribed circle (radius a) and LESS than its circumscribed circle (radius a*sqrt2).
+
+    Because the beam is rotationally symmetric, the aperture's ROLL about the optical axis does not
+    appear: clocking a square aperture cannot change T for a circular Gaussian. It would matter for an
+    astigmatic beam (separate w_x, w_y), which this tracer does not model -- q is scalar. Do not add a
+    clocking parameter until that changes; it would be a control that does nothing.
+
+    a == b gives the square case. A degenerate w returns 1 (no Gaussian -> nothing to clip), matching
+    slit_transmission and _clip_T.
+
+    The zero case differs from slit_transmission ON PURPOSE, and the difference is not a detail: there,
+    b <= 0 means "no blades are present", so nothing clips and T = 1. Here a half-width of zero means
+    the aperture is SHUT, so T = 0. Same erf, opposite degenerate meaning, because a missing slit and a
+    closed aperture are different objects. Routing this case through the kernel would silently pass a
+    beam through a closed stop."""
+    if w_mm <= 1e-9:
+        return 1.0
+    if a_mm <= 0.0 or b_mm <= 0.0:
+        return 0.0
+    return slit_transmission(a_mm, w_mm) * slit_transmission(b_mm, w_mm)
+
+
 def knife_transmission(e_mm, xc_mm, w_mm):
     """Power transmitted PAST a knife-edge (half-plane blade) whose edge sits at transverse position ``e_mm``,
     cutting into a Gaussian of 1/e^2 intensity radius ``w_mm`` centered at ``xc_mm`` (the beam chief-ray on the
@@ -2353,6 +2385,37 @@ if __name__ == "__main__":
         fails.append("LBO NCPM model T %.1f != ~256" % lbo_ncpm_temperature_estimate(1064.0))
     if lbo_ncpm_temperature_estimate(1064.0) - LBO_NCPM_TEMP_LIT_C < 80.0:
         fails.append("LBO NCPM honest gap (model vs 148 C lit) not documented")
+
+    # rectangular aperture = separable product of the verified 1-D slit clip. Checked against a
+    # direct 2-D midpoint integration of the Gaussian over the rectangle, plus the geometric
+    # bracket inscribed-circle < square < circumscribed-circle.
+    def _rect_numeric(a, b, w, n=600):
+        tot = 0.0
+        hx, hy = 2.0 * a / n, 2.0 * b / n
+        for i in range(n):
+            x = -a + (i + 0.5) * hx
+            ex = math.exp(-2.0 * x * x / (w * w))
+            s = 0.0
+            for j in range(n):
+                y = -b + (j + 0.5) * hy
+                s += math.exp(-2.0 * y * y / (w * w))
+            tot += ex * s * hx * hy
+        return tot / (math.pi * w * w / 2.0)
+
+    for _a, _b in ((0.5, 0.5), (0.7, 1.4)):
+        if not close(rect_aperture_transmission(_a, _b, 1.0), _rect_numeric(_a, _b, 1.0), 1e-4):
+            fails.append("rect aperture %gx%g != 2-D numerical integral" % (_a, _b))
+    for _a in (0.4, 0.8, 1.5):
+        _ins = 1.0 - math.exp(-2.0 * _a * _a)                      # inscribed circle, w=1
+        _cir = 1.0 - math.exp(-2.0 * 2.0 * _a * _a)                # circumscribed, radius a*sqrt2
+        _sq = rect_aperture_transmission(_a, _a, 1.0)
+        if not (_ins < _sq < _cir):
+            fails.append("square a=%g not bracketed by its circles (%.6f %.6f %.6f)" % (_a, _ins, _sq, _cir))
+    if not close(rect_aperture_transmission(0.6, 1.0e9, 1.0), slit_transmission(0.6, 1.0), 1e-12):
+        fails.append("rect aperture does not reduce to the 1-D slit as the other axis opens")
+    if rect_aperture_transmission(0.0, 1.0, 1.0) != 0.0 or not close(
+            rect_aperture_transmission(1.0e9, 1.0e9, 1.0), 1.0, 1e-12):
+        fails.append("rect aperture limits wrong (closed -> 0, wide open -> 1)")
 
     if fails:
         print("PHYSICS SELFTEST FAILED:")

--- a/optical_alignment_sim/properties.py
+++ b/optical_alignment_sim/properties.py
@@ -299,7 +299,27 @@ class OpticalElementProps(PropertyGroup):
     # only the mesh of an iris ever moves -- the optics (ports + this value) are read identically by the tracer.
     clear_aperture: FloatProperty(
         name="Clear Aperture (mm)", default=12.7, min=0.0, update=_iris_regen_update,
-        description="Clear aperture radius used for beam clipping in millimeters (default 12.7)")
+        description="Clear aperture radius used for beam clipping in millimeters (default 12.7). "
+                    "For a SQUARE/RECTANGULAR aperture_shape this is the half-width along local X")
+    # Aperture SHAPE. Circular is the default and the historical behaviour, so every existing scene
+    # traces byte-identically. Square/rectangular clip with the separable product of the verified 1-D
+    # erf slit kernel (physics.rect_aperture_transmission) -- the mesh for a dichroic or a BS cube is
+    # already square, and only the optical aperture was still a circle inscribed in it.
+    aperture_shape: EnumProperty(
+        name="Aperture shape", default='CIRCULAR',
+        items=[('CIRCULAR',    "Circular",
+                "Round clear aperture of radius Clear Aperture (T = 1 - exp(-2 a^2/w^2))"),
+               ('SQUARE',      "Square",
+                "Square clear aperture of half-width Clear Aperture (T = erf(sqrt2 a/w)^2)"),
+               ('RECTANGULAR', "Rectangular",
+                "Rectangular clear aperture: half-width Clear Aperture along local X, "
+                "Aperture half-height along local Y")],
+        description="Shape of the clear aperture used for Gaussian beam clipping. The beam is "
+                    "rotationally symmetric, so the aperture's roll about the optical axis does not "
+                    "change the transmission")
+    aperture_half_y: FloatProperty(
+        name="Aperture half-height (mm)", default=12.7, min=0.0,
+        description="Half-height along local Y for a RECTANGULAR aperture. Ignored for the other shapes")
     reflectivity: FloatProperty(
         name="Reflectivity", default=1.0, min=0.0, max=1.0,
         description="Fraction of incident optical power reflected by the element (default 1.0)")

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -285,13 +285,26 @@ def _child(ray, E, H, d, power, kind, idx, t, jones=None, q=None, evec=None, abe
 
 
 def _clip_T(ray, E, t):
-    """Gaussian power transmission through the element's circular clear aperture."""
+    """Gaussian power transmission through the element's clear aperture.
+
+    CIRCULAR (the default, and what every element did before aperture_shape existed) is the round
+    stop: T = 1 - exp(-2 a^2/w^2). SQUARE / RECTANGULAR use the separable product of the VERIFIED 1-D
+    erf slit kernel (physics.rect_aperture_transmission) -- a square dichroic or BS cube already has a
+    square MESH, and only its optical aperture was still the circle inscribed in it, discarding the
+    light a real square optic passes at its corners.
+
+    The beam is rotationally symmetric, so the aperture's roll about the optical axis does not enter."""
     if ray.q is None:
         return 1.0
     w = physics.beam_radius_m2(physics.q_propagate(ray.q, physics.abcd_free(t)), ray.wl, ray.m2)
     a = E.optics.clear_aperture
     if w <= 1e-9 or a <= 0.0:
         return 1.0
+    shape = getattr(E.optics, 'aperture_shape', 'CIRCULAR')
+    if shape == 'SQUARE':
+        return physics.rect_aperture_transmission(a, a, w)
+    if shape == 'RECTANGULAR':
+        return physics.rect_aperture_transmission(a, getattr(E.optics, 'aperture_half_y', a), w)
     return 1.0 - math.exp(-2.0 * a * a / (w * w))
 
 

--- a/optical_alignment_sim/ui.py
+++ b/optical_alignment_sim/ui.py
@@ -222,6 +222,13 @@ class OPTICS_PT_element(_OpticsPanel, Panel):
             zrow = pcol.row(align=True)
             zrow.prop(props, "imprint_zonal_px", text="Zonal Pixels")
             zrow.operator("optics.wfs_zonal_render", text="Sensor Render", icon='IMAGE_BACKGROUND')
+        # Aperture shape is orthogonal to the per-type chain above: several element types carry a
+        # clear aperture, and some of them (SHUTTER, CAVITY, ...) also have their own branch. Keeping
+        # this a separate statement means adding a type here can never swallow that branch.
+        if et in ('APERTURE', 'DICHROIC', 'BEAMSPLITTER', 'FILTER', 'WINDOW', 'POLARIZER'):
+            pcol.prop(props, "aperture_shape")
+            if props.aperture_shape == 'RECTANGULAR':
+                pcol.prop(props, "aperture_half_y")
         if et in ('MIRROR', 'PRISM_MIRROR'):
             pcol.prop(props, "coating"); pcol.prop(props, "mirror_curve")
             if props.mirror_curve != 'FLAT': pcol.prop(props, "radius_curv")

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2168,6 +2168,74 @@ bake.clear_baked(sc)
 check("no BEAM_ objects after clear", not any(o.name.startswith("BEAM_") for o in sc.objects))
 check("clear_baked frees beam meshes (no orphan leak)", len(bpy.data.meshes) <= m0)
 
+print("[aperture shape: square/rect clip, with CIRCULAR still byte-identical]")
+_c5_clear()                                # isolate the bench: a leftover source must not feed AS_D
+_ap_coll = bpy.data.collections.new("APERTURE_SHAPE_TEST"); sc.collection.children.link(_ap_coll)
+_ap_src = eg.source("AS_S", (-150, 0, 0), _PV((1, 0, 0)), _ap_coll)
+_ap_src.optics.waist_um = 500.0            # pin the beam: the suite's defaults must not size this test
+_ap = eg.aperture("AS_A", (0, 0, 0), _PV((1, 0, 0)), _ap_coll, radius=0.5)
+eg.detector("AS_D", (150, 0, 0), _PV((1, 0, 0)), _ap_coll)
+bpy.context.view_layer.update()
+
+
+def _ap_power():
+    segs = scan._trace(sc)
+    hit = next((s for s in segs if s.get("to") == "AS_D"), None)
+    return hit["power"] if hit else None
+
+
+check("a fresh element defaults to CIRCULAR (existing scenes cannot change)",
+      _ap.optics.aperture_shape == 'CIRCULAR')
+_p_circ = _ap_power()
+# guard the guard: with a ~ w the clip must actually bite, or every comparison below is vacuous
+check("the test aperture actually clips (a ~ w, not wide open)",
+      _p_circ is not None and 0.05 < _p_circ < 0.95, str(_p_circ))
+_ap.optics.aperture_shape = 'SQUARE'
+bpy.context.view_layer.update()
+_p_sq = _ap_power()
+check("a SQUARE aperture of half-width a passes MORE than the circle of radius a",
+      _p_circ is not None and _p_sq is not None and _p_sq > _p_circ, "%s vs %s" % (_p_circ, _p_sq))
+# and it must stay below the circumscribed circle -- the square is bracketed by its two circles
+_AS_A = 0.5                                # the aperture half-width used above
+_ap.optics.aperture_shape = 'CIRCULAR'
+_ap.optics.clear_aperture = _AS_A * math.sqrt(2.0)
+bpy.context.view_layer.update()
+_p_circum = _ap_power()
+_ap.optics.clear_aperture = _AS_A
+_ap.optics.aperture_shape = 'SQUARE'
+bpy.context.view_layer.update()
+check("...and LESS than the circumscribed circle of radius a*sqrt2",
+      _p_circum is not None and _p_sq < _p_circum, "%s vs %s" % (_p_sq, _p_circum))
+
+# the beam is rotationally symmetric, so the aperture's roll must not change the answer --
+# this is why no clocking parameter exists (it would be a control that does nothing).
+# Roll about the BEAM axis (world +X here) by composing the matrix; assigning rotation_euler
+# would discard the orientation _set_matrix built and swing the optic out of the path.
+_as_m0 = _ap.matrix_world.copy()
+_ap.matrix_world = _RM.Rotation(math.radians(37.0), 4, 'X') @ _ap.matrix_world
+bpy.context.view_layer.update()
+_p_rolled = _ap_power()
+check("rolling a SQUARE aperture about the optical axis changes nothing (circular beam)",
+      _p_rolled == _p_sq, "%s vs %s" % (_p_rolled, _p_sq))
+_ap.matrix_world = _as_m0
+bpy.context.view_layer.update()
+
+# RECTANGULAR: narrowing one axis must clip harder than the square
+_ap.optics.aperture_shape = 'RECTANGULAR'
+_ap.optics.aperture_half_y = 0.3
+bpy.context.view_layer.update()
+check("a RECTANGULAR aperture narrowed on one axis clips harder than the square",
+      _ap_power() < _p_sq, "%s vs %s" % (_ap_power(), _p_sq))
+
+# CIRCULAR must reproduce the ORIGINAL number exactly -- the default path is untouched
+_ap.optics.aperture_shape = 'CIRCULAR'
+_ap.optics.aperture_half_y = 12.7
+bpy.context.view_layer.update()
+check("switching back to CIRCULAR restores the byte-identical original power",
+      _ap_power() == _p_circ, "%s vs %s" % (_ap_power(), _p_circ))
+_c5_clear()
+bpy.data.collections.remove(_ap_coll)
+
 print("[unit-scale mismatch is reported, never silently absorbed]")
 from optical_alignment_sim import geometry as _geo
 check("the add-on's convention is 1 unit = 1 mm", _geo.ADDON_SCALE_LENGTH == 0.001)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -759,6 +759,45 @@ _book_ds = field.slit_metrics(0.1, n_slits=2, sep_mm=0.5, wavelength_nm=632.8, n
 check("Double slit d=0.5mm -> Delta sin(theta)=0.0012656",
       _book_ds["fringe_spacing_sin_theta"], 0.0012656, 1e-4, "Young; lambda/d")
 
+print("[rectangular clear aperture: separable product of the verified 1-D erf slit clip]")
+# Closed-form ground truth: a circular Gaussian I(x,y) ~ exp(-2(x^2+y^2)/w^2) is separable, so a
+# rectangle |x|<=a, |y|<=b transmits erf(sqrt2 a/w) * erf(sqrt2 b/w). Checked against a direct 2-D
+# midpoint integration of the same Gaussian -- an independent numeric path, not a restatement.
+
+
+def _rect_numeric(a, b, w, n=900):
+    tot = 0.0
+    hx, hy = 2.0 * a / n, 2.0 * b / n
+    for i in range(n):
+        x = -a + (i + 0.5) * hx
+        ex = math.exp(-2.0 * x * x / (w * w))
+        s = 0.0
+        for j in range(n):
+            y = -b + (j + 0.5) * hy
+            s += math.exp(-2.0 * y * y / (w * w))
+        tot += ex * s * hx * hy
+    return tot / (math.pi * w * w / 2.0)
+
+
+for _a, _b in ((0.5, 0.5), (0.7, 1.4)):
+    check("Rect aperture %.1fx%.1f (w=1) == 2-D numerical integral" % (_a, _b),
+          physics.rect_aperture_transmission(_a, _b, 1.0), _rect_numeric(_a, _b, 1.0), 2e-4,
+          "erf(sqrt2 a/w)*erf(sqrt2 b/w); midpoint quadrature of exp(-2r^2/w^2)")
+
+# geometric bracket: a square of half-width a must pass MORE than its inscribed circle (radius a)
+# and LESS than its circumscribed circle (radius a*sqrt2). Independent of the algebra above.
+_sq = physics.rect_aperture_transmission(0.8, 0.8, 1.0)
+check("Square 0.8 beats its inscribed circle", 1.0 if _sq > (1.0 - math.exp(-2.0 * 0.64)) else 0.0,
+      1.0, 1e-9, "square contains the inscribed circle of radius a")
+check("Square 0.8 loses to its circumscribed circle",
+      1.0 if _sq < (1.0 - math.exp(-2.0 * 2.0 * 0.64)) else 0.0, 1.0, 1e-9,
+      "circumscribed circle of radius a*sqrt2 contains the square")
+
+# limits: opening one axis reduces exactly to the verified 1-D slit
+check("Rect aperture -> 1-D slit as the second axis opens",
+      physics.rect_aperture_transmission(0.6, 1.0e9, 1.0), physics.slit_transmission(0.6, 1.0), 1e-12,
+      "separability: erf(sqrt2 b/w) -> 1")
+
 print("=" * 60)
 n_pass = sum(_checks)
 n_total = len(_checks)


### PR DESCRIPTION
Closes #10.

`_clip_T` applied the circular Gaussian stop, `T = 1 - exp(-2 a²/w²)`, to **every** element type — while `beamsplitter()` already builds a cube and `dichroic()` a square plate, with a comment in the code saying *"square plate upright, not a diamond"*. The mesh was square and the optical aperture was the circle inscribed in it, discarding the light a real square optic passes at its corners.

The reporter noticed the mismatch and read it as a missing mesh. It was a missing model.

## What changes

`aperture_shape` — **CIRCULAR** (default) | SQUARE | RECTANGULAR — selects the clip. CIRCULAR keeps the identical expression, so every existing scene traces byte-identically; a regression check asserts the original power returns **to the last digit** after a round trip through the other shapes.

## No new formula

A circular Gaussian is separable, so a rectangle transmits

```
T = erf(√2·a/w) · erf(√2·b/w)
```

— the product of two of the **already-verified** 1-D slit clips (`physics_verify ok=true 8/8`). `physics.rect_aperture_transmission` composes that kernel rather than restating it.

## Verified against closed form

Per `CONTRIBUTING.md`, which accepts either the Docker oracle **or** a closed-form check in `test_validation.py`. This took the second path:

- against a **direct 2-D midpoint integration** of the Gaussian over the rectangle — an independent numeric path, not a restatement of the algebra
- the geometric bracket: a square of half-width *a* passes **more** than its inscribed circle (radius *a*) and **less** than its circumscribed circle (radius *a*√2)
- the limit: opening one axis reduces exactly to the 1-D slit

The same checks also run in the bare-interpreter `physics.py` self-test.

## Deliberately no clocking parameter

The beam is rotationally symmetric, so rolling a square aperture about the optical axis **cannot** change T. A test rolls it 37° and asserts the power is unchanged to the last digit. Roll would matter only for an astigmatic beam, which this tracer does not model (`q` is scalar). Adding the knob now would repeat the dead-control mistake fixed in #4.

## A subtlety the self-test caught

The zero case differs from `slit_transmission` **on purpose**: there `b ≤ 0` means *"no blades present"* so T = 1; here a zero half-width means the stop is **shut**, so T = 0. Same erf, opposite degenerate meaning. Routing it through the kernel would have passed a beam through a closed stop — the self-test failed on exactly that before it shipped.

## Verification

**Negative control:** with the shape dispatch disabled the suite drops to **517/519** with exactly the two shape-dependent checks failing, both reading `0.8618 vs 0.8618` — the circular answer for both.

- `test_optics` **519/519** (was 512; +7)
- `test_validation` **325/325** (was 320; +5)
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- `physics.py` self-test under Python 3.13 and 3.9
- `check_release_consistency` PASS, `git diff --check` clean

## Not verified

No UI interaction was exercised. The panel row was reviewed as code — and moved out of the element-type `elif` chain it initially split, so adding a type to its tuple can never swallow that type's own branch.