### PR TITLE
Bring the scene to the optics instead of leaving the user to do it

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,14 @@ byte-identical trace, because the numbers are simply reinterpreted by Blender's 
 calls them millimetres.
 
 So work with **Scene → Units → Unit Scale = 0.001**. The examples set it for you (and say so when they
-change it). If you keep your own models at metre scale, bring them *to* the optics — scale them by 1000 on
-the way in — rather than rescaling the optics: an optic scaled to 0.001× would desynchronise from the
-physics, since a 150 mm arm would become 0.15 units and the tracer would read it as 0.15 mm.
+change it). If your scene is on another unit scale, the beam panel offers **Convert Scene to Millimetres**
+(`optics_api.convert_scene_to_mm()`): it sets Unit Scale to 0.001 *and* scales your own objects by the same
+factor, so a 2 m model stays 2 m long and optics land at true size beside it. Add-on geometry is already
+mm-authored and is left alone.
+
+The conversion goes that way round on purpose. Rescaling the optics instead would desynchronise them from
+the physics: a 150 mm arm would become 0.15 units and the tracer would read it as 0.15 mm — every
+propagation, path length and aperture clip wrong by 1000×, with no error raised.
 
 The add-on does not guess. Add a component in a scene on another unit scale and it is still placed at its
 true millimetre size, with a warning naming the factor — `add_component()` returns a `warning` key and the

--- a/mcp/optics_mcp_server.py
+++ b/mcp/optics_mcp_server.py
@@ -781,6 +781,14 @@ def bake_beams(scale: float = 0.0) -> str:
 
 
 @mcp.tool()
+def convert_scene_to_mm() -> str:
+    """Bring the scene onto the add-on's millimetre convention, keeping physical sizes. The tracer
+    reads world coordinates as mm and cannot be told otherwise, so this scales the USER's objects by
+    the same factor it changes Unit Scale by; add-on geometry is already mm-authored and untouched."""
+    return _fmt(_call("convert_scene_to_mm"))
+
+
+@mcp.tool()
 def clear_beams() -> str:
     """Remove all baked beam geometry."""
     return _fmt(_call("clear_beams"))

--- a/optical_alignment_sim/operators.py
+++ b/optical_alignment_sim/operators.py
@@ -198,6 +198,80 @@ def do_auto_detect(obj):
 
 # --- operators --------------------------------------------------------------
 
+def _addon_owned(obj):
+    """True for geometry this add-on authored, which is ALREADY in millimetres.
+
+    Optical elements carry is_optical; bench hardware and baked beams live in their own
+    collections and carry the oa_owner tag; mount parts are parented to their optic and follow
+    it. Converting a scene must not touch any of them -- they are the reference the user's own
+    models are being brought into."""
+    from . import optomech, bake
+    op = getattr(obj, "optics", None)
+    if op is not None and op.is_optical:
+        return True
+    if "oa_owner" in obj:
+        return True
+    owned_colls = {optomech.BENCH_COLL, bake.BEAM_COLL}
+    return any(c.name in owned_colls for c in obj.users_collection)
+
+
+def convert_scene_to_mm(scene):
+    """Put the scene on the add-on's millimetre convention WITHOUT resizing anything physically.
+
+    The add-on measures in millimetres and cannot be told otherwise -- the tracer reads world
+    coordinates as mm unconditionally. Rather than leave the user rescaling every imported part by
+    hand, this brings their scene to the optics: it sets Unit Scale to 0.001 and multiplies their
+    own objects by the same factor, so a 2 m model stays 2 m long and an optic added afterwards
+    lands at its true size beside it.
+
+    Only unparented objects are scaled -- children inherit their parent's transform, and scaling
+    both would square the factor. Add-on geometry is left alone (see _addon_owned): it is already
+    mm-authored, which is exactly what the scene is being converted to.
+
+    Returns {ok, factor, scaled, skipped, was_scale_length, msg}."""
+    us = scene.unit_settings
+    was = float(us.scale_length)
+    factor = was / geometry.ADDON_SCALE_LENGTH
+    # Ask the SAME question the warning asks. Blender stores scale_length as float32, so writing
+    # 0.001 reads back 0.0010000000474974513 -- a tolerance tight enough to call that "different"
+    # makes this operation non-idempotent, and pressing the button twice would scale the scene
+    # again by 1.0000000475. Sharing one predicate also stops the warning and its fix from ever
+    # disagreeing about whether a scene needs converting.
+    if geometry.unit_scale_mismatch(scene) is None:
+        return {"ok": True, "factor": 1.0, "scaled": 0, "skipped": 0, "was_scale_length": was,
+                "msg": "scene already on the millimetre convention"}
+    scaled = skipped = 0
+    for obj in scene.objects:
+        if obj.parent is not None:            # children ride their parent's transform
+            continue
+        if _addon_owned(obj):
+            skipped += 1
+            continue
+        obj.scale = tuple(s * factor for s in obj.scale)
+        obj.location = tuple(c * factor for c in obj.location)
+        scaled += 1
+    us.system = 'METRIC'
+    us.scale_length = geometry.ADDON_SCALE_LENGTH
+    us.length_unit = 'MILLIMETERS'
+    return {"ok": True, "factor": factor, "scaled": scaled, "skipped": skipped,
+            "was_scale_length": was,
+            "msg": "unit scale %g -> %g; scaled %d of your objects by %g, left %d add-on objects alone"
+                   % (was, geometry.ADDON_SCALE_LENGTH, scaled, factor, skipped)}
+
+
+class OPTICS_OT_convert_scene_units(Operator):
+    bl_idname = "optics.convert_scene_units"
+    bl_label = "Convert Scene to Millimetres"
+    bl_description = ("Set Unit Scale to 0.001 and scale your own objects to match, so they keep "
+                      "their physical size and optical components land at their true size")
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        res = convert_scene_to_mm(context.scene)
+        self.report({'INFO'}, res["msg"])
+        return {'FINISHED'}
+
+
 class OPTICS_OT_tag_element(Operator):
     bl_idname = "optics.tag_element"
     bl_label = "Tag as Optical Element"
@@ -354,6 +428,7 @@ _classes = (
     OPTICS_OT_auto_detect_ports,
     OPTICS_OT_pick_port_from_face,
     OPTICS_OT_normalize_import,
+    OPTICS_OT_convert_scene_units,
 )
 
 

--- a/optical_alignment_sim/optics_api.py
+++ b/optical_alignment_sim/optics_api.py
@@ -51,7 +51,7 @@ _TOOL_GROUPS = {
         "inspect_beam", "inspect_element", "inspect_all", "beam_profile", "ao_measure", "get_wavefront", "sensor_capture",
         "check_mechanics", "coupling_efficiency", "material_tables"],
     "build / scene": [
-        "build_example", "build_bench", "add_component", "tag_element", "swap_part", "set_param", "set_mount",
+        "build_example", "build_bench", "add_component", "tag_element", "swap_part", "set_param", "set_mount", "convert_scene_to_mm",
         "import_glass", "fdtd_derive_property"],
     "design (pure math, no scene change)": [
         "design_telescope", "design_4f", "mode_match", "optics_calc", "wave_psf", "aberrated_psf",
@@ -1619,6 +1619,17 @@ def add_component(key, location=(0.0, 0.0, 0.0)):
     if mismatch:
         out["warning"] = mismatch
     return out
+
+
+def convert_scene_to_mm():
+    """Bring the scene onto the add-on's millimetre convention, keeping physical sizes.
+
+    The tracer reads world coordinates as millimetres and cannot be told otherwise, so rather
+    than leave you rescaling every imported part by hand this scales YOUR objects by the same
+    factor it changes Unit Scale by: a 2 m model stays 2 m, and optics land at true size beside
+    it. Add-on geometry is already mm-authored and is left untouched.
+    {ok, factor, scaled, skipped, was_scale_length, msg}."""
+    return _ops.convert_scene_to_mm(_scene())
 
 
 def swap_part(name, filepath, refit_ports=False):

--- a/optical_alignment_sim/ui.py
+++ b/optical_alignment_sim/ui.py
@@ -396,6 +396,7 @@ class OPTICS_PT_trace_settings(_OpticsPanel, Panel):
     bl_order = 0
     bl_options = {'DEFAULT_CLOSED'}
     def draw(self, context):
+        from . import geometry
         layout = self.layout; props = context.scene.optics
         layout.prop(props, "trace_mode")
         if props.trace_mode == 'ORDER' and _advanced_enabled(): layout.prop(props, "order_csv")
@@ -404,6 +405,10 @@ class OPTICS_PT_trace_settings(_OpticsPanel, Panel):
             col.prop(props, "line_width")
             col.prop(props, "show_ports")
             col.prop(props, "beam_radius_scale")
+            if geometry.unit_scale_mismatch(context.scene):
+                warn = col.box().column(align=True)
+                warn.label(text="Scene is not on the mm convention", icon='ERROR')
+                warn.operator("optics.convert_scene_units", icon='MOD_LENGTH')
             col.prop(props, "oob_display")
             col.prop(props, "auto_color")
             col.prop(props, "max_segments")

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2236,6 +2236,52 @@ check("switching back to CIRCULAR restores the byte-identical original power",
 _c5_clear()
 bpy.data.collections.remove(_ap_coll)
 
+print("[convert a scene to mm: physical sizes survive, add-on geometry is left alone]")
+_c5_clear()
+_cv_coll = bpy.data.collections.new("UNIT_CONVERT_TEST"); sc.collection.children.link(_cv_coll)
+sc.unit_settings.system = 'METRIC'
+sc.unit_settings.scale_length = 1.0                     # the reporter's case: a metre-scale scene
+# the user's own model: a 2 m cube, i.e. 2 units at metre scale
+bpy.ops.mesh.primitive_cube_add(size=2.0, location=(3.0, 0.0, 0.0))
+_cv_user = bpy.context.active_object
+_cv_user.name = "USER_MODEL"
+for _c in list(_cv_user.users_collection):
+    _c.objects.unlink(_cv_user)
+_cv_coll.objects.link(_cv_user)
+_cv_user_m_before = _cv_user.dimensions.x * sc.unit_settings.scale_length      # physical metres
+_cv_user_loc_m_before = _cv_user.location.x * sc.unit_settings.scale_length
+# an add-on optic: mm-authored, so it is ALREADY on the convention being converted to
+_cv_optic = eg.source("CV_SRC", (0, 0, 0), _PV((1, 0, 0)), _cv_coll)
+_cv_optic_units_before = tuple(round(v, 6) for v in _cv_optic.dimensions)
+
+_cv = operators.convert_scene_to_mm(sc)
+bpy.context.view_layer.update()          # dimensions are depsgraph-derived
+check("convert reports the factor it applied", abs(_cv["factor"] - 1000.0) < 1e-9, str(_cv))
+# scale_length is stored as float32, so 0.001 reads back as 0.0010000000474974513
+check("convert puts the scene on the mm convention",
+      abs(sc.unit_settings.scale_length - 0.001) < 1e-9, repr(sc.unit_settings.scale_length))
+check("it scaled the user's object and skipped the add-on's",
+      _cv["scaled"] >= 1 and _cv["skipped"] >= 1, str(_cv))
+# the point of the whole operation: the user's model is the SAME PHYSICAL SIZE afterwards
+_cv_user_m_after = _cv_user.dimensions.x * sc.unit_settings.scale_length
+# RELATIVE tolerance: scale_length is float32, so the round trip carries ~5e-8 of relative error
+# (2000 units x 0.0010000000474974513 = 2.0000000949...). That is the precision Blender stores, not
+# slop in the conversion -- an absolute 1e-9 here would be asserting more than the format can hold.
+check("the user's 2 m model is still 2 m after conversion",
+      abs(_cv_user_m_after - _cv_user_m_before) < 1e-6 * _cv_user_m_before,
+      "%.9f m -> %.9f m" % (_cv_user_m_before, _cv_user_m_after))
+check("...and it is still in the same physical place",
+      abs(_cv_user.location.x * sc.unit_settings.scale_length - _cv_user_loc_m_before)
+      < 1e-6 * abs(_cv_user_loc_m_before))
+check("the mm-authored optic was NOT rescaled (it defined the target convention)",
+      tuple(round(v, 6) for v in _cv_optic.dimensions) == _cv_optic_units_before,
+      "%s -> %s" % (_cv_optic_units_before, tuple(round(v, 6) for v in _cv_optic.dimensions)))
+check("converting an already-mm scene is a no-op",
+      operators.convert_scene_to_mm(sc)["scaled"] == 0)
+_c5_clear()
+bpy.data.collections.remove(_cv_coll)
+sc.unit_settings.scale_length = 0.001
+
 print("[unit-scale mismatch is reported, never silently absorbed]")
 from optical_alignment_sim import geometry as _geo
 check("the add-on's convention is 1 unit = 1 mm", _geo.ADDON_SCALE_LENGTH == 0.001)


### PR DESCRIPTION
Addresses the remaining half of #9 — the workflow complaint — without pretending the tracer is unit-aware. **#9 can close with this**; the unit-aware measurement layer is filed separately (see below).

## Why not the fix the issue asked for

The obvious reading is "make the measurement layer unit-aware". The investigation says don't, and the reason is not effort:

Opto-mechanical hardware is mm-hardcoded — `POST_RADIUS = 6.35`, `GRID_IMPERIAL_MM = 25.4`, `BOARD_THICKNESS = 12.7` — **and geometrically coupled to the optics** through real BVH overlap tests in `check_mechanics` (`optomech.py:1670`, `_mesh_bvh_gap`). Move the optics to scene scale and leave hardware in mm, and the mechanics report goes **silently wrong**: posts floating or intersecting by a factor of a thousand, reported as fine.

A correct version means converting ~100 more sites across `optomech` / `mounts` / `assembly`. That is the "no chokepoint" problem, and it lives there — not in the tracer, where the distance→physics sites turn out to be about a dozen.

## What this does instead

The scene comes to the optics. **Convert Scene to Millimetres** sets Unit Scale to 0.001 *and* multiplies the user's objects by the same factor:

- a 2 m model is still 2 m afterwards, in the same physical place
- an optic added next lands at true size beside it
- add-on geometry is skipped — it is already mm-authored, which is the convention being converted to
- only unparented objects are scaled; children ride their parent's transform, and scaling both would square the factor

In the beam panel beside the existing mismatch warning, as `optics_api.convert_scene_to_mm()`, and over MCP.

Everything stays in the single verified mm world, so `check_mechanics` keeps telling the truth. No second supported mode, no silent-1000× risk.

## A real bug, found by its own test

The no-op guard compared the scale factor to 1.0 within `1e-9`. Blender stores `scale_length` as **float32**: writing 0.001 reads back `0.0010000000474974513`, so an already-converted scene measured as `1.0000000475` and **converted again**. Pressing the button twice would have rescaled the whole scene.

It now asks `geometry.unit_scale_mismatch()` — the same predicate the warning uses — so the warning and its fix cannot disagree about whether a scene needs converting.

The tests carry *relative* tolerances for the same reason: a 2 m model round-trips to 2.0000000949 m, which is float32's precision rather than slop in the conversion. Asserting 1e-9 there would claim more than the format holds.

## Verification

**Negative control**: restoring the `1e-9` guard drops the suite to **525/526** with exactly the idempotence check failing.

- `test_optics` **526/526** (was 519; +7 new checks)
- `test_validation` **325/325**
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- physics self-test, `check_release_consistency` PASS, `git diff --check` clean

## Not verified

No UI interaction was exercised — the panel row and operator were reviewed as code; the function they wrap is tested headlessly.