### PR TITLE
Block a closed aperture instead of passing the whole beam

### DIFF
--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -297,14 +297,24 @@ def _clip_T(ray, E, t):
     if ray.q is None:
         return 1.0
     w = physics.beam_radius_m2(physics.q_propagate(ray.q, physics.abcd_free(t)), ray.wl, ray.m2)
-    a = E.optics.clear_aperture
-    if w <= 1e-9 or a <= 0.0:
+    if w <= 1e-9:
         return 1.0
+    a = E.optics.clear_aperture
+    # Dispatch on shape FIRST. A zero half-width on a shape the user explicitly chose means the
+    # opening has zero area -- it blocks -- and routing that through the kernel is the whole point
+    # of rect_aperture_transmission's zero case. Testing `a <= 0` before this returned 1.0 and
+    # passed the full beam through a closed stop, and left an axis asymmetry: aperture_half_y = 0
+    # blocked while clear_aperture = 0 did not, though the UI allows zero for both.
     shape = getattr(E.optics, 'aperture_shape', 'CIRCULAR')
     if shape == 'SQUARE':
         return physics.rect_aperture_transmission(a, a, w)
     if shape == 'RECTANGULAR':
         return physics.rect_aperture_transmission(a, getattr(E.optics, 'aperture_half_y', a), w)
+    # CIRCULAR keeps its historical reading of zero: "no clear aperture configured", so nothing
+    # clips. Changing that would alter every existing scene that never set the field, which is a
+    # separate decision from giving the new shapes a sane closed state.
+    if a <= 0.0:
+        return 1.0
     return 1.0 - math.exp(-2.0 * a * a / (w * w))
 
 

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2236,6 +2236,53 @@ check("switching back to CIRCULAR restores the byte-identical original power",
 _c5_clear()
 bpy.data.collections.remove(_ap_coll)
 
+print("[a closed aperture blocks THROUGH THE TRACER, not just in the kernel]")
+# #16: rect_aperture_transmission returned 0 for a zero half-width, but _clip_T tested
+# `clear_aperture <= 0` BEFORE dispatching on shape and returned 1.0 -- so a closed square/rect
+# stop passed the whole beam. The kernel was right and never got called. Hence: drive this down
+# the real trace, the way a user does, rather than asserting on the kernel again.
+_c5_clear()
+_za = bpy.data.collections.new("ZERO_APERTURE_TEST"); sc.collection.children.link(_za)
+eg.source("ZA_S", (-150, 0, 0), _PV((1, 0, 0)), _za).optics.waist_um = 500.0
+_za_ap = eg.aperture("ZA_A", (0, 0, 0), _PV((1, 0, 0)), _za, radius=0.0)
+eg.detector("ZA_D", (150, 0, 0), _PV((1, 0, 0)), _za)
+bpy.context.view_layer.update()
+
+
+def _za_power():
+    hit = next((s for s in scan._trace(sc) if s.get("to") == "ZA_D"), None)
+    return None if hit is None else hit["power"]
+
+
+_za_ap.optics.aperture_shape = 'SQUARE'
+bpy.context.view_layer.update()
+check("SQUARE with a zero half-width blocks at the detector", (_za_power() or 0.0) < 1e-12,
+      str(_za_power()))
+_za_ap.optics.aperture_shape = 'RECTANGULAR'
+_za_ap.optics.aperture_half_y = 0.5
+bpy.context.view_layer.update()
+check("RECTANGULAR with a zero X half-width blocks (the reported case)",
+      (_za_power() or 0.0) < 1e-12, str(_za_power()))
+_za_ap.optics.clear_aperture = 0.5
+_za_ap.optics.aperture_half_y = 0.0
+bpy.context.view_layer.update()
+check("RECTANGULAR with a zero Y half-width blocks too (no axis asymmetry)",
+      (_za_power() or 0.0) < 1e-12, str(_za_power()))
+# and an OPEN shaped aperture still passes something, so the checks above are not vacuously dark
+_za_ap.optics.clear_aperture = 5.0
+_za_ap.optics.aperture_half_y = 5.0
+bpy.context.view_layer.update()
+check("...while an open rectangular aperture still transmits", (_za_power() or 0.0) > 0.5,
+      str(_za_power()))
+# CIRCULAR keeps its historical "zero means unset, do not clip" reading
+_za_ap.optics.aperture_shape = 'CIRCULAR'
+_za_ap.optics.clear_aperture = 0.0
+bpy.context.view_layer.update()
+check("CIRCULAR with a zero radius still means 'unconfigured' and does not clip",
+      abs((_za_power() or 0.0) - 1.0) < 1e-12, str(_za_power()))
+_c5_clear()
+bpy.data.collections.remove(_za)
+
 print("[convert a scene to mm: physical sizes survive, add-on geometry is left alone]")
 _c5_clear()
 _cv_coll = bpy.data.collections.new("UNIT_CONVERT_TEST"); sc.collection.children.link(_cv_coll)


### PR DESCRIPTION
Closes #16, reported against the aperture-shape work in #15.

## The defect

`_clip_T` tested `clear_aperture <= 0` and returned `1.0` **before** dispatching on `aperture_shape`, so a `SQUARE` or `RECTANGULAR` stop with a zero X half-width passed the full beam.

`rect_aperture_transmission` returns `0.0` for that case, and its docstring says routing it through the kernel is the point — *"routing this case through the kernel would silently pass a beam through a closed stop"*. The kernel was right and never got called.

The report also caught the axis asymmetry: `aperture_half_y = 0` reached the kernel and blocked, while `clear_aperture = 0` bypassed it and fully transmitted — though the UI allows zero for both.

## The fix

Shape dispatch comes first. `CIRCULAR` keeps its historical reading of zero — *"no clear aperture configured"*, so nothing clips — because changing that would alter every existing scene that never set the field, and that is a separate decision from giving the new shapes a sane closed state. The branch carries that reasoning inline.

## The test goes down the trace, not the kernel

The issue asked for exactly this, and it is the right call: the kernel was already correct and already tested, so a kernel test would have proved nothing. The new checks build source → zero-width stop → detector and assert the detector goes dark, plus an open-aperture case so "dark" is not vacuous, plus the `CIRCULAR` zero case to pin the historical behaviour.

This is the same lesson as the `ensure_beams` staleness fixed earlier this month — tests that call the helper directly never exercise the path a user takes — and #15's tests did not apply it.

## Verification

**Negative control**: restoring the old branch order fails exactly the two zero-X checks, both reading detector power **1.0** — the reported symptom. The zero-Y check passes even then, independently confirming the asymmetry.

- `test_optics` **531/531** (was 526; +5 new checks)
- `test_validation` **325/325**
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- physics self-test, `check_release_consistency` PASS, `git diff --check` clean