### PR TITLE
Add the decidability gate for #18, and the factor it measures with

### DIFF
--- a/optical_alignment_sim/geometry.py
+++ b/optical_alignment_sim/geometry.py
@@ -34,6 +34,19 @@ EPS = 1e-6
 ADDON_SCALE_LENGTH = 0.001          # 1 Blender unit == 1 mm
 
 
+def mm_per_unit(scene):
+    """How many millimetres one Blender unit spans in this scene. Exactly 1.0 on the mm convention.
+
+    The single conversion factor between the scene's units and the millimetres the physics is
+    written in. `scale_length` is metres-per-unit, so mm-per-unit is that times 1000: a metre scene
+    gives 1000, and the add-on's own 0.001 gives exactly 1 -- which is what keeps the millimetre
+    case bit-for-bit unchanged everywhere this is applied."""
+    sl = getattr(getattr(scene, "unit_settings", None), "scale_length", ADDON_SCALE_LENGTH)
+    if not sl or sl <= 0.0:
+        return 1.0
+    return float(sl) * 1000.0
+
+
 def unit_scale_mismatch(scene):
     """None when the scene matches the add-on's mm convention, else a one-line explanation.
 

--- a/tests/_verify_unit_equivalence.py
+++ b/tests/_verify_unit_equivalence.py
@@ -25,8 +25,16 @@ metre-scale scene works".
     physical_mm = |p2 - p1| * geometry.mm_per_unit(scene)
     assert the running total of physical_mm == segment["opl"]
 
-On the millimetre convention mm_per_unit is exactly 1.0 and this holds today. In any other scene
-it fails, and the size of the failure is the size of the lie.
+and it checks the bench is the SIZE the millimetre arguments asked for:
+
+    assert source-to-lens spacing == the 150 mm the builder call requested
+
+That second half is not decoration. Fixing only the measurement side would give a 150-METRE
+bench measured as 150 metres -- self-consistent, and useless. Both together are what a user
+means by "my metre-scale scene works".
+
+On the millimetre convention mm_per_unit is exactly 1.0 and both hold today. In any other scene
+they fail, and the size of the failure is the size of the lie.
 """
 import bpy, sys, os
 

--- a/tests/_verify_unit_equivalence.py
+++ b/tests/_verify_unit_equivalence.py
@@ -1,0 +1,117 @@
+"""Manual verification harness for #18: does the trace measure PHYSICAL millimetres?
+
+Run:
+    blender --background --factory-startup --python tests/_verify_unit_equivalence.py
+
+Not part of CI (see AGENTS.md) -- it is expected to FAIL today. It exists to make "a non-mm
+scene is a supported way to work" a decidable claim rather than an opinion, and to be the gate
+any implementation of #18 has to pass.
+
+WHAT IT CHECKS, AND WHY NOT THE OBVIOUS THING
+
+The obvious test -- build the same bench in a millimetre scene and a metre scene, compare the
+traced physics -- PASSES on a codebase where none of this works, and that is worth understanding
+before trusting any result here. Feed the same millimetre numbers to the builders in both scenes
+and today they are placed as raw Blender units, then read back as millimetres by a tracer that
+ignores `scale_length`. Two errors that cancel: the bench in the metre scene is physically a
+thousand times too large, yet every number the tracer reports is identical. A test comparing only
+those numbers cannot see the bug at all.
+
+So this ties the physics to the WORLD instead. The accumulated optical path length must equal the
+distance the beam actually spans, converted to millimetres through the scene's own unit scale.
+That cannot be satisfied by two cancelling errors -- it is the property a user means by "my
+metre-scale scene works".
+
+    physical_mm = |p2 - p1| * geometry.mm_per_unit(scene)
+    assert the running total of physical_mm == segment["opl"]
+
+On the millimetre convention mm_per_unit is exactly 1.0 and this holds today. In any other scene
+it fails, and the size of the failure is the size of the lie.
+"""
+import bpy, sys, os
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO)
+
+import optical_alignment_sim as oas
+oas.register()
+from optical_alignment_sim import elements_generic as eg, scan, geometry
+from mathutils import Vector
+
+
+def build_and_trace(scale_length):
+    """The same bench, described with the same millimetre arguments, at a given unit scale."""
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    sc = bpy.context.scene
+    sc.unit_settings.system = 'METRIC'
+    sc.unit_settings.scale_length = scale_length
+    coll = bpy.data.collections.new("EQ")
+    sc.collection.children.link(coll)
+    src = eg.source("EQ_S", (-150.0, 0.0, 0.0), Vector((1, 0, 0)), coll)
+    src.optics.waist_um = 400.0
+    eg.lens("EQ_L", (0.0, 0.0, 0.0), Vector((1, 0, 0)), coll, focal=100.0)
+    eg.detector("EQ_D", (250.0, 0.0, 0.0), Vector((1, 0, 0)), coll)
+    bpy.context.view_layer.update()
+
+    mmpu = geometry.mm_per_unit(sc)
+    # The bench must also be the SIZE the millimetre arguments asked for. Without this a change
+    # that only fixed the measurement side would pass: a 150-metre bench measured as 150 metres is
+    # self-consistent and useless. Source at -150 mm, lens at 0 -> 150 mm apart, in any scene.
+    span_mm = ((eg_objs("EQ_L").matrix_world.translation
+                - eg_objs("EQ_S").matrix_world.translation).length) * mmpu
+    rows = []
+    for s in scan._trace(sc):
+        p1, p2 = Vector(s["p1"]), Vector(s["p2"])
+        rows.append({
+            "kind": s["kind"],
+            "span_units": (p2 - p1).length,
+            "physical_mm": (p2 - p1).length * mmpu,
+            "opl": s.get("opl") or 0.0,
+            "power": round(s.get("power") or 0.0, 9),
+            "w_mm": round(s.get("w_mm") or 0.0, 6),
+        })
+    return rows, mmpu, span_mm
+
+
+def eg_objs(name):
+    return bpy.data.objects[name]
+
+
+def report(label, rows, mmpu):
+    print("%s   (mm per unit = %g)" % (label, mmpu))
+    ok, run = True, 0.0
+    for r in rows:
+        run += r["physical_mm"]
+        agree = abs(run - r["opl"]) < 1e-3
+        ok = ok and agree
+        print("    %-9s span %10.4f u = %13.4f mm physical | opl %10.4f mm   %s"
+              % (r["kind"], r["span_units"], r["physical_mm"], r["opl"],
+                 "ok" if agree else "<-- MISMATCH"))
+    return ok
+
+
+mm_rows, mm_f, mm_span = build_and_trace(0.001)
+me_rows, me_f, me_span = build_and_trace(1.0)
+
+print("=" * 78)
+numbers_match = ([(r["kind"], r["power"], r["opl"], r["w_mm"]) for r in mm_rows]
+                 == [(r["kind"], r["power"], r["opl"], r["w_mm"]) for r in me_rows])
+print("reported physics numbers identical across the two scenes:", numbers_match)
+print("  (this alone proves nothing -- see the module docstring)")
+print("-" * 78)
+ok_mm = report("millimetre scene", mm_rows, mm_f)
+print()
+ok_me = report("metre scene     ", me_rows, me_f)
+print("-" * 78)
+print("millimetre scene -- OPL equals physical distance:", ok_mm)
+print("metre scene      -- OPL equals physical distance:", ok_me)
+print()
+ok_span = abs(mm_span - 150.0) < 1e-3 and abs(me_span - 150.0) < 1e-3
+print("source->lens physical spacing (asked for 150 mm):  mm scene %.4f mm | metre scene %.4f mm  %s"
+      % (mm_span, me_span, "ok" if ok_span else "<-- WRONG SIZE"))
+print()
+if ok_mm and ok_me and ok_span:
+    print("UNIT EQUIVALENCE PASS -- the trace measures true physical millimetres in both scenes")
+    sys.exit(0)
+print("UNIT EQUIVALENCE FAIL -- the trace does not measure physical distance in every scene (#18)")
+sys.exit(1)


### PR DESCRIPTION
#18 asks for a non-mm scene to be a supported way to work. Before any of that is built, the claim needs to be **decidable**. This adds the harness that decides it, plus `geometry.mm_per_unit()` — millimetres per Blender unit, exactly `1.0` on the add-on's own convention, so anything keyed on it is a no-op there.

The harness is a manual tool (`tests/_verify_*.py`, outside CI per `AGENTS.md`) and it **FAILS today on purpose**. That is its job: it states the target rather than asserting current behaviour.

## The part worth reading

The obvious formulation — build the same bench in a mm scene and a metre scene, compare the traced physics — **passes on today's code**, and passing is exactly wrong.

Feed the same millimetre numbers to the builders in both scenes and they are placed as raw Blender units, then read back as millimetres by a tracer that ignores `scale_length`. Two errors that cancel: the metre-scene bench is physically a thousand times too large while every reported number is identical. A test comparing only those numbers cannot see the bug at all.

I wrote that version first and it went green. The docstring carries the story so the next person does not repeat it.

## What the gate actually checks

It ties the physics to the world, and it checks the size too:

```
physical_mm = |p2 - p1| * geometry.mm_per_unit(scene)
assert running total of physical_mm == segment["opl"]
assert source-to-lens spacing == the 150 mm that was asked for
```

The second assertion matters: fixing only the measurement side would give a 150-**metre** bench measured as 150 metres — self-consistent and useless. Both halves together are what a user means by "my metre-scale scene works".

Today:

```
millimetre scene   (mm per unit = 1)
    SOURCE    span 127.5000 u =    127.5000 mm physical | opl 127.5000 mm   ok
metre scene        (mm per unit = 1000)
    SOURCE    span 127.5000 u = 127500.0000 mm physical | opl 127.5000 mm   <-- MISMATCH
```

A beam that travels 127.5 metres is reported as 127.5 mm.

## Scope

No behaviour change — `mm_per_unit` has no callers in the add-on yet, and the harness never runs in CI. `test_optics` **531/531**, physics self-test, `check_release_consistency` PASS.

A separate comment on #18 records what happened when I tried to make the gate green, and why it changes the blocker.