### PR TITLE
Make the exported report say what diagnose() found

### DIFF
--- a/optical_alignment_sim/optics_api.py
+++ b/optical_alignment_sim/optics_api.py
@@ -632,7 +632,12 @@ def export_report(filepath=None, title="Optical Bench Report", with_render=False
     prof = beam_profile() if any(True for _o in _scene().objects
                                  if getattr(_o, "optics", None) and getattr(_o.optics, "is_optical", False)) else {}
     rows = dash.get("elements", [])
-    issues = diag.get("issues") or diag.get("problems") or []
+    # diagnose() publishes its findings under "diagnostics" -- its docstring says so and so does its
+    # return. Reading "issues"/"problems" found neither key, so every report said "No issues flagged"
+    # with n_issues=0 no matter how bad the bench was. A report that quietly certifies a broken bench
+    # is worse than no report. Read the documented contract; the old names stay only as a fallback in
+    # case a caller hands us an older-shaped dict.
+    issues = diag.get("diagnostics") or diag.get("issues") or diag.get("problems") or []
     parts = ["<!doctype html><meta charset=utf-8><title>%s</title>" % _html.escape(title),
              "<style>body{background:#0d0d10;color:#e8e8ea;font:14px/1.5 system-ui,sans-serif;margin:0;padding:28px}"
              "h1{color:#f4f4f6}h2{color:#4a8db0;border-bottom:1px solid #33343a;padding-bottom:4px;margin-top:28px}"
@@ -657,13 +662,18 @@ def export_report(filepath=None, title="Optical Bench Report", with_render=False
     parts.append("</table>")
 
     if issues:
-        parts.append("<h2>Diagnostics</h2><table><tr><th>Severity</th><th>Issue</th><th>Where</th></tr>")
+        parts.append("<h2>Diagnostics</h2>"
+                     "<table><tr><th>Severity</th><th>Issue</th><th>Where</th><th>Detail</th></tr>")
         for it in issues:
             sev = str(it.get("severity", it.get("state", "")))
             cls = "bad" if sev in ("BAD", "WARN", "high", "medium") else "ok"
-            parts.append("<tr><td class=%s>%s</td><td>%s</td><td>%s</td></tr>" % (
+            # `detail` is the field that says WHY -- a table of kinds and element names tells a
+            # reader something is wrong without telling them what, which is barely better than the
+            # empty section this used to print.
+            parts.append("<tr><td class=%s>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>" % (
                 cls, _html.escape(sev), _html.escape(str(it.get("issue", it.get("problem", it.get("kind", ""))))),
-                _html.escape(str(it.get("where", it.get("element", ""))))))
+                _html.escape(str(it.get("where", it.get("element", "")))),
+                _html.escape(str(it.get("detail", "")))))
         parts.append("</table>")
     else:
         parts.append("<h2>Diagnostics</h2><p class=ok>No issues flagged.</p>")

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1910,6 +1910,31 @@ _rep = optics_api.export_report(filepath="/tmp/oas_report.html", title="Regress"
 _rep_html = open("/tmp/oas_report.html").read() if _rep.get("ok") else ""
 check("export_report: self-contained HTML with the dashboard table", _rep.get("ok") and "<table>" in _rep_html and _rep["n_elements"] >= 4, str(_rep.get("path")))
 
+# The report must AGREE with diagnose(). It used to read keys diagnose() never returns, so every
+# report certified a clean bench however broken it was -- and the check above could not see that,
+# because it only asks whether a table exists. Build a bench with a known BAD finding and compare
+# the two, rather than asserting the report is merely well-formed.
+_c5_clear()
+_dr = bpy.data.collections.new("REPORT_DIAG_TEST"); sc.collection.children.link(_dr)
+eg.source("RD_S", (-150, 0, 0), _PV((1, 0, 0)), _dr)
+eg.detector("RD_DARK", (0, 200, 0), _PV((0, 1, 0)), _dr)      # off the beam path -> dark_detector
+bpy.context.view_layer.update()
+_rd_diag = optics_api.diagnose()
+_rd_kinds = {d.get("kind") for d in _rd_diag.get("diagnostics", [])}
+check("the probe bench really does raise a diagnostic (not a vacuous comparison)",
+      _rd_diag.get("counts", {}).get("BAD", 0) >= 1 and "dark_detector" in _rd_kinds, str(_rd_kinds))
+_rd_rep = optics_api.export_report(filepath="/tmp/oas_report_diag.html", title="DiagRegress")
+_rd_html = open("/tmp/oas_report_diag.html").read() if _rd_rep.get("ok") else ""
+check("export_report counts the same findings diagnose() reports",
+      _rd_rep.get("n_issues") == len(_rd_diag.get("diagnostics", [])) and _rd_rep["n_issues"] >= 1,
+      "report %s vs diagnose %s" % (_rd_rep.get("n_issues"), len(_rd_diag.get("diagnostics", []))))
+check("...and the HTML names the finding instead of claiming the bench is clean",
+      "dark_detector" in _rd_html and "No issues flagged" not in _rd_html)
+check("...and it shows the detail that says why", "RD_DARK" in _rd_html and "<th>Detail</th>" in _rd_html)
+_c5_clear()
+bpy.data.collections.remove(_dr)
+optics_api.build_example("michelson")          # restore a bench for the checks that follow
+
 print("[beam profile w(z)]")
 optics_api.build_example("newton_rings")
 bp = optics_api.beam_profile("NR_D")


### PR DESCRIPTION
Closes #21.

## The defect

`export_report()` read `diag.get("issues") or diag.get("problems")`. `diagnose()` returns **neither** — it publishes `diagnostics`, as its own docstring and return statement both say.

So the list was always empty. Every report printed **"No issues flagged"** with `n_issues=0` no matter how broken the bench was — for every user and every agent that called it. A report that quietly certifies a bad bench is worse than no report.

## The fix

Read the documented contract. The old names stay only as a fallback in case a caller hands us an older-shaped dict.

The rendering already handled the real record shape through its key fallbacks (`severity`, `kind`, `element`), so the read was the only defect — **but** the table dropped `detail`, the field that says *why*. A list of kinds and element names tells a reader something is wrong without telling them what, which is barely better than the empty section it used to print. Added as a column; that part is a small deliberate widening of the fix, not a side effect.

## Why the existing test missed it

It asserts a table exists and that elements were exported — never that the report agrees with `diagnose()`. Well-formed and wrong.

The new check builds a bench with a known `BAD` finding, **asserts the probe really raises one** (so the comparison cannot pass vacuously), then compares count, kind and detail against the report.

## Verification

**Negative control**: with the old keys restored the suite drops to **532/535** with the three new checks failing, reading `report 0 vs diagnose 2` — two findings counted as none, which is the reported symptom.

- `test_optics` **535/535** (was 531; +4 new checks)
- `test_validation` **325/325**
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- physics self-test, `check_release_consistency` PASS, `git diff --check` clean