### PR TITLE
Let a scene declare its units, and measure physical millimetres when it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ The conversion goes that way round on purpose. Rescaling the optics instead woul
 the physics: a 150 mm arm would become 0.15 units and the tracer would read it as 0.15 mm — every
 propagation, path length and aperture clip wrong by 1000×, with no error raised.
 
+**If you genuinely work in another unit scale**, turn on **Scene units are authoritative**
+(`scene.optics.scene_units_authoritative`). Component arguments stay in millimetres — the API is unchanged —
+but they are then placed at true physical size and the trace measures physical millimetres, verified by
+`tests/_verify_unit_equivalence.py`. It is off by default and that default is deliberate: Blender's factory
+Unit Scale is 1.0 and this add-on never set it, so a scene reading 1.0 is almost always one where nobody
+touched units, not a metre-scale scene. Guessing from Unit Scale alone reinterprets every such scene and
+shrinks it by a thousand.
+
+**Opto-mechanical hardware is not supported while it is on.** Posts, breadboards and mounts are
+millimetre-hardcoded and `check_mechanics()` compares real mesh geometry, so it would collision-check parts
+a factor of a thousand apart. `dress_bench()` and `check_mechanics()` refuse rather than report a wrong
+answer.
+
 The add-on does not guess. Add a component in a scene on another unit scale and it is still placed at its
 true millimetre size, with a warning naming the factor — `add_component()` returns a `warning` key and the
 UI reports it. Supporting non-mm scenes properly means making the measurement layer unit-aware; that is

--- a/optical_alignment_sim/elements_generic.py
+++ b/optical_alignment_sim/elements_generic.py
@@ -154,11 +154,23 @@ def _tag(obj, element_type, **params):
 
 
 def _set_matrix(obj, loc, rot3=None):
-    """Place obj at loc with optional 3x3 world rotation matrix."""
-    if rot3 is None:
-        obj.matrix_world = Matrix.Translation(loc)
-    else:
-        obj.matrix_world = Matrix.Translation(loc) @ rot3.to_4x4()
+    """Place obj at loc (MILLIMETRES) with an optional 3x3 world rotation.
+
+    Every builder here funnels through this, and every builder's coordinates and dimensions are
+    millimetres -- that is the documented API. A scene that has DECLARED its unit scale
+    authoritative needs those millimetres expressed in its units, so the translation is divided by
+    mm-per-unit and the object carries the reciprocal scale, which shrinks the mm-authored mesh to
+    true physical size. Otherwise mm_per_unit() is exactly 1.0, both are the identity, and this is
+    the same single matrix assignment it always was."""
+    from . import geometry
+    mmpu = geometry.mm_per_unit(bpy.context.scene)
+    if mmpu == 1.0:
+        obj.matrix_world = (Matrix.Translation(loc) if rot3 is None
+                            else Matrix.Translation(loc) @ rot3.to_4x4())
+        return
+    t = Matrix.Translation(Vector(loc) / mmpu)
+    m = t if rot3 is None else t @ rot3.to_4x4()
+    obj.matrix_world = m @ Matrix.Scale(1.0 / mmpu, 4)
 
 
 def _basis(x, y):

--- a/optical_alignment_sim/geometry.py
+++ b/optical_alignment_sim/geometry.py
@@ -40,11 +40,27 @@ def mm_per_unit(scene):
     The single conversion factor between the scene's units and the millimetres the physics is
     written in. `scale_length` is metres-per-unit, so mm-per-unit is that times 1000: a metre scene
     gives 1000, and the add-on's own 0.001 gives exactly 1 -- which is what keeps the millimetre
-    case bit-for-bit unchanged everywhere this is applied."""
+    case bit-for-bit unchanged everywhere this is applied.
+
+    It returns 1.0 unless the scene has DECLARED that its unit scale is authoritative, and that
+    guard is the load-bearing part. Blender's factory scale_length is 1.0 and this add-on has never
+    set it, so a scene reading 1.0 is overwhelmingly one where nobody touched units rather than a
+    metre-scale scene. Keying off scale_length alone reinterprets every one of those -- including
+    every bench this project's own tests build -- and shrinks it by a thousand. That was measured:
+    it broke 20 existing behaviours, one of them a periscope whose vertical fold came out 0.1
+    instead of 100. Intent is declared here, never inferred."""
+    opt = getattr(scene, "optics", None)
+    if not getattr(opt, "scene_units_authoritative", False):
+        return 1.0
     sl = getattr(getattr(scene, "unit_settings", None), "scale_length", ADDON_SCALE_LENGTH)
     if not sl or sl <= 0.0:
         return 1.0
-    return float(sl) * 1000.0
+    mmpu = float(sl) * 1000.0
+    # Snap to exactly 1.0 inside float32 noise. Blender stores scale_length as float32, so writing
+    # 0.001 reads back 0.0010000000474974513 and this would return 1.0000000475 -- enough to send a
+    # DECLARED millimetre scene down the conversion path and stop it being byte-identical, for a
+    # difference that is pure storage precision. Same trap as the scene converter's idempotence.
+    return 1.0 if abs(mmpu - 1.0) < 1e-6 else mmpu
 
 
 def unit_scale_mismatch(scene):

--- a/optical_alignment_sim/optics_api.py
+++ b/optical_alignment_sim/optics_api.py
@@ -1520,7 +1520,27 @@ def tilt_null(detector=None, mirrors=None, gain=1.0, eps=0.04, max_iters=8, pist
     return res
 
 
+def _hardware_unsupported_here():
+    """Opto-mechanics is millimetre-hardcoded, so it cannot follow a declared non-mm scene.
+
+    POST_RADIUS, GRID_IMPERIAL_MM and BOARD_THICKNESS are millimetre literals, and check_mechanics
+    compares real mesh geometry with BVH overlap tests. With the optics at true physical size in a
+    metre scene and the hardware still authored in millimetres, those tests would compare geometry
+    a factor of a thousand apart and report posts that float or interpenetrate as fine. A mechanics
+    gate that silently passes is worse than no gate, so this refuses instead."""
+    scene = _scene()
+    if geometry.mm_per_unit(scene) == 1.0:
+        return None
+    return {"error": "opto-mechanical hardware is millimetre-only and is not supported while "
+                     "'Scene units are authoritative' is on: it would be placed and collision-"
+                     "checked a factor of %g out. Turn the declaration off, or keep the bench in "
+                     "a millimetre scene." % geometry.mm_per_unit(scene)}
+
+
 def check_mechanics():
+    blocked = _hardware_unsupported_here()
+    if blocked:
+        return blocked
     return {"worst": mounts.check_mechanics(_scene())}
 
 
@@ -1716,6 +1736,9 @@ def dress_bench(enable=True):
     """Spawn (enable=True) or remove (enable=False) the procedural breadboard + posts + pedestals
     + mount rings. The grid is then exposed via get_state()['bench']. Trace is unaffected (optics
     are not moved). Returns the object count and the grid."""
+    blocked = _hardware_unsupported_here()
+    if blocked and enable:                 # removing hardware is always allowed
+        return blocked
     scene = _scene()
     if enable:
         n = _optomech.dress(scene)

--- a/optical_alignment_sim/properties.py
+++ b/optical_alignment_sim/properties.py
@@ -801,6 +801,19 @@ class OpticalSceneProps(PropertyGroup):
         name="Beam width scale", default=1.0, min=0.05, max=20.0,
         description="Multiply the baked beam tube width. The tube still follows the real Gaussian "
                     "w(z); this scales it for rendering, so 1.0 is physical size")
+    # Does this scene's Unit Scale MEAN anything? Default False, and that default is the whole
+    # point. Blender's factory scale_length is 1.0 and this add-on has never set it, so a scene
+    # reading 1.0 is overwhelmingly one where nobody touched units -- not a metre-scale scene.
+    # Inferring intent from scale_length reinterprets every such scene as metres and shrinks it by
+    # a thousand; that was measured, and it broke 20 existing behaviours. So intent is DECLARED,
+    # never guessed: while this is off, geometry.mm_per_unit() returns exactly 1.0 and every
+    # unit-aware code path is the identity.
+    scene_units_authoritative: BoolProperty(
+        name="Scene units are authoritative", default=False,
+        description="Treat this scene's Unit Scale as the real one, so millimetre component "
+                    "arguments are placed at true physical size and the trace measures physical "
+                    "millimetres. Leave off unless you deliberately work in a non-millimetre "
+                    "scene; opto-mechanical hardware is not supported while it is on")
     show_ports: BoolProperty(name="Show ports", default=True)
     # How IR / UV beams are DRAWN (viewport, bake and SVG alike). Display only -- the trace is
     # untouched, so switching this never changes a power, a Jones vector or a segment count.

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -84,6 +84,25 @@ def _first_out(props):
     return _find_port(props, 'OUT')
 
 
+# Millimetres per Blender unit for the trace in progress. The tracer's arithmetic is entirely in
+# millimetres, so every POSITION it reads is converted on the way in and the emitted p1/p2 are
+# converted back to world units on the way out (the overlay and the bake draw with them). Every
+# distance is derived from those positions, so none of them needs converting individually -- there
+# is no length site left to forget. Unless the scene declares its units authoritative this is
+# exactly 1.0 and every multiplication below is the identity.
+_mmpu = 1.0
+
+
+def _wp(obj, local_position):
+    """Port position in MILLIMETRES."""
+    return geometry.world_port(obj, local_position) * _mmpu
+
+
+def _wc(obj):
+    """Element centre in MILLIMETRES."""
+    return obj.matrix_world.translation * _mmpu
+
+
 def interaction_surface(obj):
     """Return (point, normal, aperture) of the surface the beam interacts with:
     the REFLECT plane for reflective elements, otherwise the IN port plane."""
@@ -192,7 +211,7 @@ def _seg(ray, p2, to_obj, sn=None):
              ev[0] * e2[0] + ev[1] * e2[1] + ev[2] * e2[2])
     qd = physics.q_propagate(ray.q, physics.abcd_free(seg_len)) if ray.q is not None else None
     return {
-        "p1": ray.p1.copy(), "p2": p2.copy(), "kind": ray.kind,
+        "p1": ray.p1 / _mmpu, "p2": p2 / _mmpu, "kind": ray.kind,
         "from": ray.from_obj.name if ray.from_obj else None,
         "to": to_obj.name if to_obj else None,
         "power": round(ray.power, 4), "wavelength": ray.wl, "parent": ray.parent,
@@ -482,7 +501,8 @@ def _build_world_bvhtree(E):
         if not bm.faces:
             bm.free()
             return None
-        bm.transform(E.matrix_world)
+        bm.transform(Matrix.Scale(_mmpu, 4) @ E.matrix_world if _mmpu != 1.0
+                     else E.matrix_world)
         tree = BVHTree.FromBMesh(bm)
     except Exception:
         try:
@@ -768,7 +788,7 @@ def _slit_T(ray, E, H, t):
         return 1.0
     b = max(E.optics.slit_width, 0.0) * 0.5
     axis = _clip_axis_world(E, E.optics.slit_angle)
-    center = E.matrix_world.translation
+    center = _wc(E)
     off = abs((H - center).dot(axis))                  # chief-ray offset along the clipped axis (~0 if centered)
     # transmit the band [off - b, off + b]: T = 0.5(erf(sqrt2(off+b)/w) + erf(sqrt2(b-off)/w)). When off=0 this
     # reduces to erf(sqrt2 b/w) (the verified centered slit); off>0 shifts the band off the beam, clipping more.
@@ -784,7 +804,7 @@ def _knife_T(ray, E, H, t):
     if w <= 1e-9:
         return 1.0
     axis = _clip_axis_world(E, E.optics.knife_angle)
-    center = E.matrix_world.translation
+    center = _wc(E)
     xc = (H - center).dot(axis)                        # chief-ray position on the cut axis (relative to stage center)
     e = E.optics.knife_position
     return physics.knife_transmission(e, xc, w)
@@ -933,8 +953,8 @@ def _prism_faces(E):
     """World (point, outward-normal) of a prism's entry (IN) and exit (OUT) faces."""
     op = E.optics
     ip, opo = _find_port(op, 'IN'), _find_port(op, 'OUT')
-    pin = (geometry.world_port(E, ip.local_position), geometry.world_normal(E, ip.local_normal)) if ip else None
-    pout = (geometry.world_port(E, opo.local_position), geometry.world_normal(E, opo.local_normal)) if opo else None
+    pin = (_wp(E, ip.local_position), geometry.world_normal(E, ip.local_normal)) if ip else None
+    pout = (_wp(E, opo.local_position), geometry.world_normal(E, opo.local_normal)) if opo else None
     return pin, pout
 
 
@@ -948,7 +968,7 @@ def _glass_seg(ray, p2, E, n_glass, kind):
     j = ray.jones
     qd = physics.q_propagate(ray.q, physics.abcd_free(seg_len)) if ray.q is not None else None
     return {
-        "p1": ray.p1.copy(), "p2": p2.copy(), "kind": kind,
+        "p1": ray.p1 / _mmpu, "p2": p2 / _mmpu, "kind": kind,
         "from": ray.from_obj.name if ray.from_obj else None,
         "to": E.name if E else None,
         "power": round(ray.power, 4), "wavelength": ray.wl, "parent": ray.parent,
@@ -1009,6 +1029,8 @@ def _route_fold(glass_ray, E, fold_faces, segments, parent_idx, n_glass):
 
 
 def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
+    global _mmpu
+    _mmpu = geometry.mm_per_unit(scene)   # 1.0 unless the scene declares its units authoritative
     elems = [o for o in scene.objects
              if getattr(o, "optics", None) and o.optics.is_optical]
     order = _order_list(scene)
@@ -1019,10 +1041,12 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
     geometry_table = []
     for E in elems:
         surface = interaction_surface(E)
+        if _mmpu != 1.0 and surface[0] is not None:   # the trace works in mm; this helper
+            surface = (surface[0] * _mmpu, surface[1], surface[2])   # stays world for diagnostics
         port_surfaces = []
         if E.optics.element_type == 'CIRCULATOR':
             for p in _circulator_ports(E.optics):
-                port_surfaces.append((geometry.world_port(E, p.local_position),
+                port_surfaces.append((_wp(E, p.local_position),
                                       geometry.world_normal(E, p.local_normal),
                                       p.clear_aperture or E.optics.clear_aperture))
         record = (E, surface, port_surfaces)
@@ -1068,7 +1092,7 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
                 spectrum = [(w, wt / tw) for w, wt in pairs]
             else:
                 spectrum = [(sp.wavelength, 1.0)]
-            P = geometry.world_port(src, op.local_position)
+            P = _wp(src, op.local_position)
             D = geometry.world_normal(src, op.local_normal)
             m2 = max(getattr(sp, 'm2', 1.0), 1.0)
             for wl_i, sw in spectrum:
@@ -1257,13 +1281,13 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             if N >= 2:
                 # identify the ENTRY port: the one whose world position is nearest the hit point H (the
                 # face the ray actually crossed). _find_next already gated H to a single port's aperture.
-                entry = min(range(N), key=lambda k: (geometry.world_port(E, ports[k].local_position) - H).length)
+                entry = min(range(N), key=lambda k: (_wp(E, ports[k].local_position) - H).length)
                 T_thru = min(max(getattr(op, 'element_transmittance', 1.0), 0.0), 1.0)   # universal insertion loss (default 1.0)
                 iso_lin = physics.db_to_linear(max(getattr(op, 'isolation_db', 20.0), 0.0))
                 nxt = ports[(entry + 1) % N]                # main path -> NEXT port (the cyclic route)
                 prv = ports[(entry - 1) % N]                # isolation leak -> PREVIOUS port (non-reciprocity is here)
                 # main child: through power from P(i+1) along its outward normal; polarization state unchanged.
-                Pn = geometry.world_port(E, nxt.local_position)
+                Pn = _wp(E, nxt.local_position)
                 Dn = geometry.world_normal(E, nxt.local_normal)
                 jn = (ray.jones if T_thru == 1.0 else
                       physics.scale(ray.jones, math.sqrt(T_thru)) if ray.jones else None)
@@ -1272,7 +1296,7 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
                 # isolation child: the small directivity leak from P(i-1). Same energy bookkeeping as the
                 # through path scaled by the dB ratio; pol carried unchanged (sqrt for the field amplitude).
                 if prv is not nxt and ray.power * T_thru * iso_lin >= 1e-9:
-                    Pp = geometry.world_port(E, prv.local_position)
+                    Pp = _wp(E, prv.local_position)
                     Dp = geometry.world_normal(E, prv.local_normal)
                     ji = (physics.scale(ray.jones, math.sqrt(iso_lin)) if T_thru == 1.0 and ray.jones else
                           physics.scale(ray.jones, math.sqrt(T_thru * iso_lin)) if ray.jones else None)
@@ -1530,7 +1554,7 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             ipo, opo = _find_port(op, 'IN'), _find_port(op, 'OUT')
             fwd = None
             if ipo and opo:
-                fwd = geometry.world_port(E, opo.local_position) - geometry.world_port(E, ipo.local_position)
+                fwd = _wp(E, opo.local_position) - _wp(E, ipo.local_position)
                 fwd = fwd.normalized() if fwd.length > 1e-9 else None
             if fwd is not None and ray.dir.dot(fwd) < 0.0:
                 continue                                  # backward -> absorbed
@@ -1593,7 +1617,7 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
                 tir_n = geometry.world_normal(E, tirp.local_normal)
                 # fold the in-glass ray off the TIR face. The face midpoint is the in-glass ray's hit; use the
                 # ray-plane intersection through the TIR port position for the segment break.
-                tir_pt = geometry.world_port(E, tirp.local_position)
+                tir_pt = _wp(E, tirp.local_position)
                 hb = _ray_plane(glass_ray.p1, glass_ray.dir, tir_pt, tir_n)
                 Hb = hb[0] if hb is not None else (glass_ray.p1 + glass_ray.dir * 1.0)
                 gseg, opl_b, _qd = _glass_seg(glass_ray, Hb, E, n_g, 'GLASS')
@@ -1652,7 +1676,7 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
                 if cemp is None:
                     continue
                 cem_n = geometry.world_normal(E, cemp.local_normal)
-                cem_pt = geometry.world_port(E, cemp.local_position)
+                cem_pt = _wp(E, cemp.local_position)
                 hc = _ray_plane(glass_ray.p1, glass_ray.dir, cem_pt, cem_n)
                 Hc = hc[0] if hc is not None else (glass_ray.p1 + glass_ray.dir * 1.0)
                 gseg, opl_c, _qd = _glass_seg(glass_ray, Hc, E, n_g, 'GLASS')   # crown leg (n_g)
@@ -1688,7 +1712,7 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
                     if fp is None:
                         ok = False
                         break
-                    folds.append((geometry.world_port(E, fp.local_position),
+                    folds.append((_wp(E, fp.local_position),
                                   geometry.world_normal(E, fp.local_normal)))
                 if not ok:
                     continue

--- a/optical_alignment_sim/ui.py
+++ b/optical_alignment_sim/ui.py
@@ -407,8 +407,13 @@ class OPTICS_PT_trace_settings(_OpticsPanel, Panel):
             col.prop(props, "beam_radius_scale")
             if geometry.unit_scale_mismatch(context.scene):
                 warn = col.box().column(align=True)
-                warn.label(text="Scene is not on the mm convention", icon='ERROR')
-                warn.operator("optics.convert_scene_units", icon='MOD_LENGTH')
+                if props.scene_units_authoritative:
+                    warn.label(text="Working in declared scene units", icon='CHECKMARK')
+                    warn.label(text="Opto-mech hardware unsupported here", icon='ERROR')
+                else:
+                    warn.label(text="Scene is not on the mm convention", icon='ERROR')
+                    warn.operator("optics.convert_scene_units", icon='MOD_LENGTH')
+                warn.prop(props, "scene_units_authoritative")
             col.prop(props, "oob_display")
             col.prop(props, "auto_color")
             col.prop(props, "max_segments")

--- a/tests/_verify_unit_equivalence.py
+++ b/tests/_verify_unit_equivalence.py
@@ -3,9 +3,15 @@
 Run:
     blender --background --factory-startup --python tests/_verify_unit_equivalence.py
 
-Not part of CI (see AGENTS.md) -- it is expected to FAIL today. It exists to make "a non-mm
-scene is a supported way to work" a decidable claim rather than an opinion, and to be the gate
-any implementation of #18 has to pass.
+Not part of CI (see AGENTS.md). It was written to FAIL, as the decidable form of "a non-mm scene
+is a supported way to work", and it now PASSES -- so it has turned from a target into a guard.
+Run it after touching the tracer, the element builders or geometry.mm_per_unit().
+
+It only means anything because the scenes below DECLARE their unit scale authoritative
+(`scene.optics.scene_units_authoritative`). Without that declaration mm_per_unit() is 1.0 by
+design and every conversion is the identity: Blender's factory scale_length is 1.0 and this
+add-on never set it, so a scene reading 1.0 is almost always one where nobody touched units.
+Inferring intent from scale_length instead was measured to break 20 behaviours.
 
 WHAT IT CHECKS, AND WHY NOT THE OBVIOUS THING
 
@@ -53,6 +59,10 @@ def build_and_trace(scale_length):
     sc = bpy.context.scene
     sc.unit_settings.system = 'METRIC'
     sc.unit_settings.scale_length = scale_length
+    # DECLARE that this scene's unit scale means what it says. Without this the add-on treats
+    # scale_length as noise -- rightly, since Blender's default is 1.0 and most scenes never touch
+    # it -- and every conversion below is the identity. The declaration is the feature.
+    sc.optics.scene_units_authoritative = True
     coll = bpy.data.collections.new("EQ")
     sc.collection.children.link(coll)
     src = eg.source("EQ_S", (-150.0, 0.0, 0.0), Vector((1, 0, 0)), coll)
@@ -102,10 +112,17 @@ mm_rows, mm_f, mm_span = build_and_trace(0.001)
 me_rows, me_f, me_span = build_and_trace(1.0)
 
 print("=" * 78)
-numbers_match = ([(r["kind"], r["power"], r["opl"], r["w_mm"]) for r in mm_rows]
-                 == [(r["kind"], r["power"], r["opl"], r["w_mm"]) for r in me_rows])
-print("reported physics numbers identical across the two scenes:", numbers_match)
-print("  (this alone proves nothing -- see the module docstring)")
+# Exact equality is the wrong bar here: scale_length is stored as float32, so a metre scene's
+# divide-then-multiply round trip carries ~1e-7 of relative error. Report the worst relative
+# difference instead of a bare boolean, so float noise does not read as a physics discrepancy.
+_worst = 0.0
+for _a, _b in zip(mm_rows, me_rows):
+    for _k in ("power", "opl", "w_mm"):
+        _d = abs(_a[_k] - _b[_k]) / max(abs(_a[_k]), 1e-30)
+        _worst = max(_worst, _d)
+print("physics agrees across the two scenes to a relative %.1e  (float32 scale_length noise is ~1e-7)"
+      % _worst)
+print("  (agreement alone proves nothing -- see the module docstring)")
 print("-" * 78)
 ok_mm = report("millimetre scene", mm_rows, mm_f)
 print()

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -2308,6 +2308,40 @@ check("CIRCULAR with a zero radius still means 'unconfigured' and does not clip"
 _c5_clear()
 bpy.data.collections.remove(_za)
 
+print("[declared scene units: intent is stated, never inferred from scale_length]")
+from optical_alignment_sim import geometry as _geo
+# The whole reason this is a declaration: Blender's factory scale_length is 1.0 and the add-on has
+# never set it, so a scene reading 1.0 is almost always one where nobody touched units. Keying the
+# unit-aware paths off scale_length alone was measured to break 20 behaviours -- a periscope's
+# vertical fold came out 0.1 instead of 100 -- because every default scene was read as metres.
+_ua_prev_decl = sc.optics.scene_units_authoritative
+_ua_prev_sl = sc.unit_settings.scale_length
+sc.unit_settings.scale_length = 1.0
+sc.optics.scene_units_authoritative = False
+check("a metre-looking scene is NOT treated as metres unless declared",
+      _geo.mm_per_unit(sc) == 1.0, str(_geo.mm_per_unit(sc)))
+sc.optics.scene_units_authoritative = True
+check("...and IS once declared", abs(_geo.mm_per_unit(sc) - 1000.0) < 1e-3, str(_geo.mm_per_unit(sc)))
+sc.unit_settings.scale_length = 0.001
+check("a declared millimetre scene still gives exactly 1.0 (the identity that keeps mm untouched)",
+      _geo.mm_per_unit(sc) == 1.0, str(_geo.mm_per_unit(sc)))
+
+# opto-mechanics is mm-hardcoded and BVH-coupled to the optics, so it must REFUSE rather than
+# report a bench it measured a factor of a thousand out
+sc.unit_settings.scale_length = 1.0
+sc.optics.scene_units_authoritative = True
+_ua_mech = optics_api.check_mechanics()
+_ua_dress = optics_api.dress_bench(enable=True)
+check("check_mechanics refuses in a declared non-mm scene rather than reporting a wrong answer",
+      "error" in _ua_mech, str(_ua_mech))
+check("dress_bench refuses too (hardware would be placed 1000x out)",
+      "error" in _ua_dress, str(_ua_dress))
+sc.optics.scene_units_authoritative = False
+check("...and both work again once the declaration is off",
+      "error" not in optics_api.check_mechanics())
+sc.unit_settings.scale_length = _ua_prev_sl
+sc.optics.scene_units_authoritative = _ua_prev_decl
+
 print("[convert a scene to mm: physical sizes survive, add-on geometry is left alone]")
 _c5_clear()
 _cv_coll = bpy.data.collections.new("UNIT_CONVERT_TEST"); sc.collection.children.link(_cv_coll)
@@ -2355,7 +2389,6 @@ bpy.data.collections.remove(_cv_coll)
 sc.unit_settings.scale_length = 0.001
 
 print("[unit-scale mismatch is reported, never silently absorbed]")
-from optical_alignment_sim import geometry as _geo
 check("the add-on's convention is 1 unit = 1 mm", _geo.ADDON_SCALE_LENGTH == 0.001)
 
 


### PR DESCRIPTION
Closes #18.

## Why the first attempt failed, and what changed

The attempt recorded on #18 keyed the unit-aware paths off `scale_length` and **broke 20 behaviours**. Blender's factory `scale_length` is 1.0 and this add-on never set it, so a scene reading 1.0 is almost always one where *nobody touched units* — not a metre-scale scene. Every default bench got reinterpreted as metres and shrunk by a thousand; a periscope's vertical fold came out **0.1 instead of 100**.

`scale_length` does not carry intent. So intent is **declared**.

`scene_units_authoritative` defaults to `False`, and that default is the design. While it is off, `geometry.mm_per_unit()` returns exactly `1.0` and every unit-aware path is the identity — which is why the 535 existing checks are untouched.

## What engages when it is on

**Placement** — `_set_matrix`, the funnel all 33 builders go through, divides its millimetre coordinates by mm-per-unit and gives the object the reciprocal scale, so mm-authored meshes land at true physical size.

**Measurement** — the tracer converts every **position** it reads into millimetres (ports, element centres, the BVH mesh, the source origin) and converts `p1`/`p2` back to world units on output for the overlay and the bake. Positions, not distances: every length is derived from them, so there is no distance site left to forget.

**The builder API does not change.** Component arguments stay in millimetres in every scene — that is what makes the same call reproduce the same physical bench.

## Opto-mechanics refuses instead of answering wrongly

`POST_RADIUS`, `GRID_IMPERIAL_MM` and `BOARD_THICKNESS` are millimetre literals, and `check_mechanics` compares real mesh geometry with BVH overlap. In a declared metre scene it would collision-check parts a factor of a thousand apart and report floating posts as fine.

A mechanics gate that silently passes is worse than no gate, so `dress_bench()` and `check_mechanics()` return an error naming the factor. That limit is in the README, not just the code.

## A real bug its own test caught

Writing `scale_length = 0.001` reads back `0.0010000000474974513`, so the factor came out `1.0000000475` — enough to send a **declared millimetre** scene down the conversion path and stop it being byte-identical, for pure storage precision. The factor now snaps to exactly 1.0 inside float32 noise. Same trap as the scene converter's idempotence.

## The gate turned from a target into a guard

`tests/_verify_unit_equivalence.py` was written to fail. It now passes, and its docstring says so:

```
millimetre scene   (mm per unit = 1)
    SOURCE    span 127.5000 u =    127.5000 mm physical | opl 127.5000 mm   ok
metre scene        (mm per unit = 1000)
    SOURCE    span   0.1275 u =    127.5000 mm physical | opl 127.5000 mm   ok

source->lens physical spacing (asked for 150 mm):  mm 150.0000 | metre 150.0000  ok
UNIT EQUIVALENCE PASS
```

The two scenes agree to a relative **1.2e-7** — float32 `scale_length` noise — and the harness reports it as noise rather than as a bare inequality.

## Verification

**Negative control**: removing the declaration guard reproduces the original disaster exactly — **516/538**, the same cage / dressing / periscope / collision failures.

- `test_optics` **541/541** (was 535; +6 new checks)
- `test_validation` **325/325**
- `test_mesh_health` PASS (30 element meshes, 311 mount parts)
- unit-equivalence harness **PASS**
- physics self-test, `check_release_consistency` PASS, `git diff --check` clean

## Not verified

No UI interaction was exercised — the panel row was reviewed as code; everything it toggles is tested headlessly.