### PR TITLE
Release 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to the **Blender Optics Simulator** (`optical_alignment_sim`
 here. The format follows [Keep a Changelog](https://keepachangelog.com/), and the project uses
 semantic versioning.
 
+## [0.29.0] — Say it, don't guess it: declared scene units, shaped apertures, and reports that stop lying — 2026-08-18
+
+### Added — a non-millimetre scene is a supported way to work
+- **`scene_units_authoritative`.** Turn it on and component arguments — still millimetres, the API
+  is unchanged — are placed at true physical size while the trace measures physical millimetres.
+  Off by default, and that default is the design: Blender's factory Unit Scale is 1.0 and this
+  add-on never set it, so a scene reading 1.0 is almost always one where nobody touched units.
+  Inferring intent from Unit Scale instead was measured to break 20 behaviours, a periscope's
+  vertical fold landing at 0.1 instead of 100. While it is off, `mm_per_unit()` returns exactly 1.0
+  and every unit-aware path is the identity. Verified by `tests/_verify_unit_equivalence.py`, which
+  was written to fail and now guards the property instead.
+  **Opto-mechanics is unsupported in that mode and says so:** posts and breadboards are
+  millimetre-hardcoded and `check_mechanics()` compares real mesh geometry, so `dress_bench()` and
+  `check_mechanics()` refuse rather than collision-check parts a factor of a thousand apart.
+- **Convert Scene to Millimetres.** Sets Unit Scale to 0.001 *and* scales your own objects by the
+  same factor, so a 2 m model stays 2 m and optics land at true size beside it. Add-on geometry is
+  skipped — it already defines the convention.
+- **Aperture shape.** `CIRCULAR` (default) / `SQUARE` / `RECTANGULAR`. A square dichroic or BS cube
+  already had a square mesh while its optical aperture was the circle inscribed in it, discarding
+  the light a real square optic passes at its corners. The non-circular clip is the separable
+  product of the verified 1-D erf slit kernel, checked against 2-D numerical integration and the
+  bracket that a square passes more than its inscribed circle and less than its circumscribed one.
+
+### Fixed — three things that reported success while being wrong
+- **`export_report()` said "No issues flagged" on every bench.** It read `issues`/`problems`;
+  `diagnose()` publishes `diagnostics`, so the list was always empty and `n_issues` always 0 no
+  matter how broken the bench. The diagnostics table also now carries the `detail` field that says
+  *why*.
+- **A closed square/rectangular aperture passed the whole beam.** `_clip_T` returned early on
+  `clear_aperture <= 0` before dispatching on shape, so a stop with zero area transmitted
+  everything — and only on the X axis, since a zero Y half-width blocked correctly.
+- **The unit-scale mismatch was silent.** `add_component()` and `build_example()` now carry a
+  `warning`, the UI reports it, and building an example from the panel no longer changes your unit
+  settings without saying so.
+
+### Changed
+- **CI runs Blender 5.1.1 as well as 4.2.3.** The add-on ships a 5.x-specific artifact (cp313
+  wheels) that no job had ever exercised on 5.x. `CONTRIBUTING.md` had claimed this matrix existed;
+  now it does.
+
 ## [0.28.0] — One colour convention, a path readout that admits its limits, and a shutter — 2026-08-11
 
 ### Fixed — a bake control that never did anything

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
   - gaussian-beam
   - polarization
   - mcp
-version: "0.28.0"
-date-released: "2026-08-11"
+version: "0.29.0"
+date-released: "2026-08-18"
 doi: "10.5281/zenodo.20778997"
 identifiers:
   - type: doi

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ ready-to-paste APA / BibTeX.
   author  = {Çobanoğlu, Muhammet Emir},
   title   = {Blender Optics Simulator},
   year    = {2026},
-  version = {0.28.0},
+  version = {0.29.0},
   doi     = {10.5281/zenodo.20778997},
   license = {GPL-3.0-or-later},
   url     = {https://github.com/emircbngl/blender-optics-simulator}

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,10 +25,10 @@
 <body>
 <div class="wrap">
   <h1>Blender Optics Simulator</h1>
-  <p class="tag">Live ray tracing &amp; auto-alignment for optical benches · v0.28.0</p>
+  <p class="tag">Live ray tracing &amp; auto-alignment for optical benches · v0.29.0</p>
 
   <p><b>One-click install (Blender 4.2+):</b></p>
-  <p><a class="cta" href="https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.28.0/optical_alignment_sim-0.28.0.zip?repository=https%3A%2F%2Femircbngl.github.io%2Fblender-optics-simulator%2Findex.json&blender_version_min=4.2.0">⤓ Drag this into Blender to install</a></p>
+  <p><a class="cta" href="https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.29.0/optical_alignment_sim-0.29.0.zip?repository=https%3A%2F%2Femircbngl.github.io%2Fblender-optics-simulator%2Findex.json&blender_version_min=4.2.0">⤓ Drag this into Blender to install</a></p>
   <p class="hint">Drag the button onto an open Blender window. Blender installs the add-on
      <b>and</b> subscribes you to update notifications — no URL to type. Make sure
      <b>Edit ▸ Preferences ▸ System ▸ Network ▸ Allow Online Access</b> is on.</p>

--- a/docs/index.json
+++ b/docs/index.json
@@ -7,7 +7,7 @@
    "id": "optical_alignment_sim",
    "name": "Optics Simulator",
    "tagline": "Live ray tracing & auto-alignment for optical benches",
-   "version": "0.28.0",
+   "version": "0.29.0",
    "type": "add-on",
    "maintainer": "Emir <emircbngl@gmail.com>",
    "license": [
@@ -22,9 +22,9 @@
    "tags": [
     "Render"
    ],
-   "archive_url": "https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.28.0/optical_alignment_sim-0.28.0.zip",
-   "archive_size": 449348,
-   "archive_hash": "sha256:61ecd70adbfa0c7e3a8700bf3810cf510d9c31970094b77f84d898d31cd7cd16"
+   "archive_url": "https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.29.0/optical_alignment_sim-0.29.0.zip",
+   "archive_size": 457964,
+   "archive_hash": "sha256:d1e1f8a505ccd31e8274f44091e812017fdc9451cd12e0470a9685c322a16878"
   }
  ]
 }

--- a/optical_alignment_sim/blender_manifest.toml
+++ b/optical_alignment_sim/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "optical_alignment_sim"
-version = "0.28.0"
+version = "0.29.0"
 name = "Optics Simulator"
 tagline = "Live ray tracing & auto-alignment for optical benches"
 maintainer = "Emir <emircbngl@gmail.com>"


### PR DESCRIPTION
Cuts the release for the eleven changes merged since 0.28.0.

## Version

**Minor, not patch.** New features with no breaking API change this time — `scene_units_authoritative` and `aperture_shape` are both additive and both default to the previous behaviour.

Bumped in the six places that declare it — `blender_manifest.toml`, `CITATION.cff` (version + date-released), `CHANGELOG.md`, `docs/index.json`, `docs/index.html`, `README.md`'s BibTeX — plus the pages-repo `archive_size` and `archive_hash` for the v0.29.0 asset.

`tools/check_release_consistency.py`: **PASS** (pre mode, 0.29.0).

## What ships

**Added**
- **#23** — `scene_units_authoritative`: a non-millimetre scene becomes a supported way to work. Off by default, because Blender's factory Unit Scale is 1.0 and this add-on never set it, so a scene reading 1.0 is almost always one where nobody touched units. Opto-mechanics refuses in that mode rather than collision-checking parts a factor of a thousand apart.
- **#17** — Convert Scene to Millimetres: brings your objects onto the convention instead of leaving you to rescale every import.
- **#15** — aperture shape (circular / square / rectangular), so a square dichroic stops clipping like the circle inscribed in it.

**Fixed — three things that reported success while being wrong**
- **#21** — `export_report()` said "No issues flagged" on every bench; it read keys `diagnose()` never returns.
- **#16** — a closed square/rectangular aperture passed the whole beam, and only on the X axis.
- **#9/#14** — the unit-scale mismatch was silent, including the panel quietly changing your unit settings.

**Changed**
- **#13** — CI runs Blender 5.1.1 as well as 4.2.3. The add-on ships cp313 wheels for 5.x that no job had ever exercised there, and `CONTRIBUTING.md` had claimed the matrix already existed.

## Release asset

`optical_alignment_sim-0.29.0.zip` — 46 entries (45 `.py` + `blender_manifest.toml`, flat), 457964 bytes, `sha256:d1e1f8a505ccd31e8274f44091e812017fdc9451cd12e0470a9685c322a16878`. Same shape as the v0.28.0 asset.

## Still outstanding after this merges

`CITATION.cff` has no `Version DOI for v0.29.0` yet — Zenodo mints it once the GitHub release exists, so it lands in a follow-up commit. The release-consistency `--post` check treats it as informational pre-release.