### PR TITLE
Stop telling users the baked beams are only for rendering

### DIFF
--- a/optical_alignment_sim/bake.py
+++ b/optical_alignment_sim/bake.py
@@ -242,7 +242,11 @@ def ensure_beams(context):
 class OPTICS_OT_bake_beams(Operator):
     bl_idname = "optics.bake_beams"
     bl_label = "Bake Beams to Mesh"
-    bl_description = "Create emission-cylinder meshes from the current beam path (for rendering)"
+    # "(for rendering)" told users the opposite of the truth: these ARE real mesh objects in
+    # COL_BEAMS, so they export to glTF/FBX/OBJ like any other geometry. A user who wanted the
+    # beams in a slide deck read that parenthetical and concluded the beams were viewport-only.
+    bl_description = ("Turn the traced beam path into real mesh objects in COL_BEAMS -- editable, "
+                      "renderable, and exported with the rest of the scene")
     bl_options = {'REGISTER', 'UNDO'}
 
     # A SCALE, not a radius in mm: the tube follows the real w(z), this widens it for a figure.

--- a/optical_alignment_sim/ui.py
+++ b/optical_alignment_sim/ui.py
@@ -574,7 +574,7 @@ class OPTICS_PT_render(_OpticsPanel, Panel):
     bl_options = {'DEFAULT_CLOSED'}
     def draw(self, context):
         layout = self.layout; row = layout.row(align=True)
-        row.operator("optics.bake_beams", text="Bake Beams", icon='OUTLINER_OB_MESH'); row.operator("optics.clear_baked", text="Clear Baked", icon='X')
+        row.operator("optics.bake_beams", text="Beams to Mesh", icon='OUTLINER_OB_MESH'); row.operator("optics.clear_baked", text="Clear Baked", icon='X')
         layout.label(text="Camera"); grid = layout.grid_flow(columns=4, align=True)
         for preset in ('HERO', 'TOP', 'FRONT', 'SIDE'): grid.operator("optics.set_camera", text=preset.title()).preset = preset
         layout.label(text="Background"); layout.prop(context.scene.optics, "bg_preset", text=""); layout.prop(context.scene.optics, "realistic_optics")


### PR DESCRIPTION
Raised in #1: a user asked for *"an option to convert the traced laser beams into solid/editable mesh geometry"*, because the beams *"appear to be rendered as viewport-only visual effects rather than actual mesh objects"* and did not survive export.

**That option has existed all along.** *Bake Beams* creates real `BEAM_##` mesh objects in `COL_BEAMS` that export like any other geometry.

The reason a careful user concluded otherwise is that the tooltip said so:

> Create emission-cylinder meshes from the current beam path **(for rendering)**

Someone looking for exportable geometry reads that parenthetical and moves on. The operator's own label says *"to Mesh"* and the description walks it back. It now says what the objects actually are, and the button reads **Beams to Mesh** rather than *Bake Beams*, which is jargon for the same thing.

## Deliberately not changed

Two other things made this hard to find, and both are layout decisions rather than defects — worth a maintainer's call, not a drive-by:

- the panel lives under **Present → Render**; the request asked for it in **Simulate**
- that panel is `DEFAULT_CLOSED`

## Verification

`test_optics` **541/541**, `check_release_consistency` PASS. No behaviour change — the operator does exactly what it did.