### PR TITLE
Record the v0.29.0 Zenodo version DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,6 +34,9 @@ identifiers:
     value: "10.5281/zenodo.20778997"
     description: "Concept DOI — always resolves to the latest version"
   - type: doi
+    value: "10.5281/zenodo.22001222"
+    description: "Version DOI for v0.29.0"
+  - type: doi
     value: "10.5281/zenodo.21893057"
     description: "Version DOI for v0.28.0"
   - type: doi


### PR DESCRIPTION
Zenodo minted `10.5281/zenodo.22001222` for the v0.29.0 release.

Verified against the record before writing it in — `metadata.version` is `v0.29.0` and its `conceptdoi` is this project's `10.5281/zenodo.20778997`, so it is this release's version DOI and not a neighbouring record.

`tools/check_release_consistency.py --post` now passes; this was the only outstanding item after the release.