### PR TITLE
Seat reflective optics on the plane they reflect from (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the **Blender Optics Simulator** (`optical_alignment_sim`
 here. The format follows [Keep a Changelog](https://keepachangelog.com/), and the project uses
 semantic versioning.
 
+## [Unreleased]
+
+### Fixed — the drawn beam folds on the coating, not inside the glass
+- **Reflective optics are seated on the plane they reflect from** ([#25](https://github.com/emircbngl/blender-optics-simulator/issues/25)). Every reflective builder
+  modelled its substrate straddling the object origin, so the coated face stood proud of the
+  REFLECT plane the tracer folds the beam at: 3 mm on a mirror, 1.5 mm on a dichroic, 2.5 mm on a
+  grating. The beam visibly turned *inside* the substrate. The mesh is now slid so the surface the
+  axial ray strikes sits on that plane.
+  For a **curved** mirror that point is the apex, not the rim — the mesh's spherical cap carries a
+  fixed cosmetic sag (the focal power comes from `radius_curv`, never from the mesh), so seating the
+  rim would still have folded the beam 2 mm off the face it visibly hits. The seat depth is now read
+  from the profile itself so the two cannot drift apart.
+  **Two optics are exempt by construction, not by oversight:** a cube beamsplitter's coating is its
+  internal 45° diagonal, which already passes through the origin, and a corner-cube retroreflector
+  is angle-insensitive with no single face to seat.
+  Guarded by five checks that cast a ray down the local axis and demand the hit land on the REFLECT
+  plane; with the fix removed all five fail, and with only the flat case fixed exactly the two
+  curved ones fail. **No traced number changed** — the segment digests for the `green_doubler` and
+  `michelson` benches are identical before and after, because the tracer reads ports and
+  `matrix_world`, never the mesh.
+
 ## [0.29.0] — Say it, don't guess it: declared scene units, shaped apertures, and reports that stop lying — 2026-08-18
 
 ### Added — a non-millimetre scene is a supported way to work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,16 @@ semantic versioning.
   **Two optics are exempt by construction, not by oversight:** a cube beamsplitter's coating is its
   internal 45° diagonal, which already passes through the origin, and a corner-cube retroreflector
   is angle-insensitive with no single face to seat.
-  Guarded by five checks that cast a ray down the local axis and demand the hit land on the REFLECT
-  plane; with the fix removed all five fail, and with only the flat case fixed exactly the two
-  curved ones fail. **No traced number changed** — the segment digests for the `green_doubler` and
+  **The mount follows the glass.** The opto-mechanics lays every part out from the object origin on
+  the assumption that the substrate straddles it, so seating the mesh alone left the KM retaining
+  ring -- the physical stop for the mirror edge -- floating 3.6 mm clear of the face it retains,
+  with the plate bore cutting through the coating. The seat shift is recorded on the object and the
+  mount frame is slid by the same amount, restoring the exact optic/mount relationship: the ring's
+  back face now sits on the glass front. Optics that were never seated read 0.0 and are untouched.
+  Guarded by six checks -- five that cast a ray down the local axis and demand the hit land on the REFLECT
+  plane, and one that demands the retaining ring still contact the seated face. With the fix removed
+  all five axial checks fail; with only the flat case fixed exactly the two curved ones fail; and
+  with the mount left behind the ring check fails. **No traced number changed** — the segment digests for the `green_doubler` and
   `michelson` benches are identical before and after, because the tracer reads ports and
   `matrix_world`, never the mesh.
 

--- a/optical_alignment_sim/elements_generic.py
+++ b/optical_alignment_sim/elements_generic.py
@@ -168,8 +168,15 @@ def _seat_optical_face(obj, face_z):
     NOT applied blindly to everything reflective. A cube beamsplitter's coated surface is its
     internal 45-degree diagonal, which already passes through the origin, and a corner cube is
     modelled as angle-insensitive with no single face to seat. Both are correct as built; shifting
-    them would introduce the very error this fixes."""
+    them would introduce the very error this fixes.
+
+    The shift is RECORDED on the object because the opto-mechanics builds every mount part from the
+    object origin, assuming the glass straddles it. Left unrecorded, the mount stays put while the
+    glass slides out of it -- measured as the KM retaining ring, the physical stop for the mirror
+    edge, floating 3.6 mm clear of the face it is meant to retain. ``_build_mount`` reads this and
+    follows the glass, so the optic/mount relationship is exactly what it was before seating."""
     obj.data.transform(Matrix.Translation((0.0, 0.0, -face_z)))
+    obj["optic_seat_shift"] = float(face_z)
 
 
 def _set_matrix(obj, loc, rot3=None):

--- a/optical_alignment_sim/elements_generic.py
+++ b/optical_alignment_sim/elements_generic.py
@@ -153,6 +153,25 @@ def _tag(obj, element_type, **params):
             setattr(op, k, v)
 
 
+def _seat_optical_face(obj, face_z):
+    """Slide an optic's MESH so its optical surface sits on the object origin.
+
+    The engine's optical surface is the REFLECT port, and every reflective builder puts that port at
+    local z = 0 -- the object origin. The substrate, though, was built centred on that origin, so a
+    front-surface optic reflected from the middle of its own glass: a 6 mm mirror turned the beam
+    3 mm behind the coating it is drawn with (#25).
+
+    This moves the MESH, not the port, so no traced number changes anywhere -- and it gives the
+    origin a meaning: place a mirror at P and the beam turns at P, with the glass behind it, which
+    is what a front-surface optic is.
+
+    NOT applied blindly to everything reflective. A cube beamsplitter's coated surface is its
+    internal 45-degree diagonal, which already passes through the origin, and a corner cube is
+    modelled as angle-insensitive with no single face to seat. Both are correct as built; shifting
+    them would introduce the very error this fixes."""
+    obj.data.transform(Matrix.Translation((0.0, 0.0, -face_z)))
+
+
 def _set_matrix(obj, loc, rot3=None):
     """Place obj at loc (MILLIMETRES) with an optional 3x3 world rotation.
 
@@ -896,9 +915,11 @@ def mirror(name, loc, in_dir, out_dir, coll=None, size=25.0, mirror_curve='FLAT'
     n = (Vector(out_dir).normalized() - Vector(in_dir).normalized())
     n = n.normalized() if n.length > 1e-6 else Vector((0, 0, 1))
     if mirror_curve in ('CONCAVE', 'CONVEX'):
-        o = _revolve(name, _mirror_profile(size * 0.5, mirror_curve), coll,
-                     seg=_seg_for_aperture(size), smooth=True)
+        prof = _mirror_profile(size * 0.5, mirror_curve)
+        face_z = prof[0][1]     # apex (r=0): where the on-axis beam actually strikes, NOT the rim
+        o = _revolve(name, prof, coll, seg=_seg_for_aperture(size), smooth=True)
     else:
+        face_z = 3.0            # flat 6 mm substrate: the coated +Z face
         o = _disc(name, size * 0.5, 6.0, coll)    # Ø1" substrate, 6 mm thick; +Z = coated front face
         _bevel(o, 0.5, 2)
     o.data.materials.clear(); o.data.materials.append(MATS["mirror"]())
@@ -906,6 +927,11 @@ def mirror(name, loc, in_dir, out_dir, coll=None, size=25.0, mirror_curve='FLAT'
     _accent(o, "subglass", lambda c, nrm: nrm.z < 0.55)
     _tag(o, 'MIRROR', clear_aperture=size * 0.5, reflectivity=1.0,
          mirror_curve=mirror_curve, radius_curv=radius_curv)
+    # Seat the point the AXIAL ray hits onto the REFLECT plane. For a curved mirror that is the apex,
+    # not the rim: the mesh's spherical cap carries a fixed cosmetic sag (see _mirror_profile), so
+    # seating the rim would still turn the beam 2 mm off the surface it visibly strikes -- #25 again,
+    # smaller. Taken from the profile itself so the two cannot drift apart.
+    _seat_optical_face(o, face_z)
     _add_port(o, "IN", 'IN', (0, 0, 2.0), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _z_to(n))     # local +Z (face/REFLECT normal) -> bisector n
@@ -1796,6 +1822,7 @@ def dichroic(name, loc, in_dir, reflect_dir, coll=None, split=0.5, size=25.0,
     _accent(o, "coatdich", lambda c, nrm: nrm.z > 0.7)   # the wavelength-selective coated +Z face
     _tag(o, 'DICHROIC', split_ratio=split, clear_aperture=size * 0.5, reflectivity=1.0,
          pass_type=pass_type, cut_nm=cut_nm)
+    _seat_optical_face(o, 1.5)      # 3 mm plate: the coated +Z face is the optical surface
     _add_port(o, "IN", 'IN', (0, 0, 1.5), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _roll_upright(_z_to(n), n))   # square plate upright, not a diamond
@@ -1818,6 +1845,7 @@ def grating(name, loc, in_dir, out_dir, coll=None, size=25.0, lines_per_mm=1200.
     o.data.materials.clear(); o.data.materials.append(MATS["grating"]())
     _tag(o, 'GRATING', clear_aperture=size * 0.5, reflectivity=0.8,
          lines_per_mm=lines_per_mm, grating_order=order, grating_profile=grating_profile)
+    _seat_optical_face(o, 2.5)      # 5 mm plate: the ruled +Z face is the optical surface
     _add_port(o, "IN", 'IN', (0, 0, 2.5), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _roll_upright(_z_to(n), n))   # square upright + grooves vertical

--- a/optical_alignment_sim/optomech.py
+++ b/optical_alignment_sim/optomech.py
@@ -414,7 +414,12 @@ def _build_mount(o, coll, idx):
     et = op.element_type
     mt = getattr(op, "mount_type", 'FIXED')
     ca = max(getattr(op, "clear_aperture", 10.0), 6.0)
-    p = o.matrix_world.translation
+    # Follow the glass. Mount parts are laid out from the object origin on the assumption that the
+    # substrate straddles it; a seated optic (#25) has its mesh slid back so the coated face sits on
+    # the origin, so the mount frame is slid by the same amount. 0.0 -- and therefore the untouched
+    # original layout -- for every optic that was never seated.
+    _seat = float(o.get("optic_seat_shift", 0.0) or 0.0)
+    p = (o.matrix_world @ Vector((0.0, 0.0, -_seat))) if _seat else o.matrix_world.translation
     mw = Matrix.Translation(p) @ o.matrix_world.to_3x3().to_4x4()
     pre = BENCH_PREFIX
     nm = "%02d" % idx

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -645,6 +645,34 @@ for _lbl, _mk in (("flat mirror",    lambda: eg.mirror("S_f", (0, 0, 0), (1, 0, 
     check("#25: %s turns the beam on its coated face (axial hit on the REFLECT plane)" % _lbl,
           _z is not None and abs(_z) < 1e-3, "axial hit z = %s" % ("miss" if _z is None else "%.3f" % _z))
 
+# --- #25 follow-up: seating the glass must not leave the MOUNT behind -------------------------
+# The opto-mechanics lays every part out from the object origin assuming the substrate straddles it.
+# Sliding the mesh without telling it left the KM retaining ring -- the physical stop for the mirror
+# edge -- floating 3.6 mm clear of the face it retains, and the plate bore cutting through the
+# coating. Demand the ring still CONTACT the glass front.
+_kcoll = bpy.data.collections.new("KMSEAT"); sc.collection.children.link(_kcoll)
+_km = eg.mirror("KM_seat", (0, 0, 100.0), (1, 0, 0), (0, 1, 0), coll=_kcoll)
+bpy.context.view_layer.update()
+optomech.dress(sc)
+bpy.context.view_layer.update()
+_ax = _km.matrix_world.to_3x3() @ _Vec((0, 0, 1))
+def _span(ob):
+    pr = [((ob.matrix_world @ v.co) - _km.location).dot(_ax) for v in ob.data.vertices]
+    return (min(pr), max(pr))
+_gfront = _span(_km)[1]
+# the scene already carries mounts from earlier benches, and part names carry an index, not the
+# optic name -- so pick the retainer belonging to THIS mirror by proximity, not by first match
+_rings = [ob for ob in sc.objects if "KMretainer" in ob.name and ob.type == 'MESH']
+_ring = min(_rings, key=lambda ob: (ob.matrix_world.translation - _km.location).length, default=None)
+if _ring is not None and (_ring.matrix_world.translation - _km.location).length > 30.0:
+    _ring = None        # nothing of this mirror's own: fail loudly rather than measure a stranger
+check("#25: the KM retaining ring still contacts the seated mirror's face (mount followed the glass)",
+      _ring is not None and abs(_span(_ring)[0] - _gfront) < 0.05,
+      "glass front %.3f vs ring back %s" % (_gfront, "none" if _ring is None else "%.3f" % _span(_ring)[0]))
+for _o in list(_kcoll.objects):
+    eg.drop_example_object(_o)
+bpy.data.collections.remove(_kcoll)
+
 for _o in list(_mcoll.objects):
     eg.drop_example_object(_o)
 bpy.data.collections.remove(_mcoll)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -601,9 +601,20 @@ check("phenomenon: produce(accept=True) emerges Talbot (z_T = 2 d^2/lambda ~ 31.
       _grp.get("ok") and abs((_grp.get("produced") or {}).get("talbot_distance_mm", 0.0) - 31.6056) < 0.1,
       str((_grp.get("produced") or {}).get("talbot_distance_mm")))
 
-def _frontrange(o):          # z-spread of the FRONT-half verts: ~0 for a flat front, big if curved
-    zs = [v.co.z for v in o.data.vertices if v.co.z > 0.1]
-    return (max(zs) - min(zs)) if zs else 0.0
+def _frontrange(o):
+    """z-spread of the FRONT-most verts: ~0 for a flat front, big if curved.
+
+    Selected relative to the mesh's OWN extent, not against a fixed z > 0.1. The old absolute cut
+    assumed the substrate straddled the origin; once the mesh was seated so its coated face sits on
+    the REFLECT plane (#25) the whole body lies at z <= 0, no vertex cleared the threshold, and this
+    returned 0.0 for curved and flat alike -- reporting a shape regression where the shape was
+    unchanged. A test about shape should not depend on where the shape sits."""
+    zs = [v.co.z for v in o.data.vertices]
+    if not zs:
+        return 0.0
+    lo, hi = min(zs), max(zs)
+    front = [z for z in zs if z >= hi - 0.4 * (hi - lo)]
+    return (max(front) - min(front)) if front else 0.0
 
 
 _cmesh = eg.mirror("CM_curved", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll, mirror_curve='CONCAVE', radius_curv=300.0)
@@ -611,6 +622,29 @@ _cflat = eg.mirror("CM_flat", (40, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll, mir
 check("concave mirror has a curved front (vs near-flat front)", _frontrange(_cmesh) > _frontrange(_cflat) + 1.0,
       "%.2f vs %.2f" % (_frontrange(_cmesh), _frontrange(_cflat)))
 check("mirror curvature recorded on the optic", _cmesh.optics.mirror_curve == 'CONCAVE')
+
+# --- #25: the beam must turn ON the coated face, not behind it -------------------------------
+# Cast down the local axis and demand the surface the AXIAL ray strikes sits on the REFLECT plane
+# (z=0). Before the fix a flat mirror's coating sat 3 mm proud and a curved mirror's apex +/-2 mm,
+# so the drawn beam folded inside the glass. Exempt by construction, NOT overlooked: a cube
+# beamsplitter's coating is its internal 45-degree diagonal (already through the origin) and a
+# corner cube is angle-insensitive with no single face to seat.
+def _axial_hit_z(o):
+    hit, loc, _n, _i = o.ray_cast(_Vec((0, 0, 60.0)), _Vec((0, 0, -1.0)))
+    return loc.z if hit else None
+
+for _lbl, _mk in (("flat mirror",    lambda: eg.mirror("S_f", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll)),
+                  ("concave mirror", lambda: eg.mirror("S_c", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll,
+                                                       mirror_curve='CONCAVE', radius_curv=300.0)),
+                  ("convex mirror",  lambda: eg.mirror("S_x", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll,
+                                                       mirror_curve='CONVEX', radius_curv=300.0)),
+                  ("dichroic",       lambda: eg.dichroic("S_d", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll)),
+                  ("grating",        lambda: eg.grating("S_g", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll,
+                                                        lines_per_mm=1200.0))):
+    _z = _axial_hit_z(_mk())
+    check("#25: %s turns the beam on its coated face (axial hit on the REFLECT plane)" % _lbl,
+          _z is not None and abs(_z) < 1e-3, "axial hit z = %s" % ("miss" if _z is None else "%.3f" % _z))
+
 for _o in list(_mcoll.objects):
     eg.drop_example_object(_o)
 bpy.data.collections.remove(_mcoll)


### PR DESCRIPTION
Closes #25.

The reporter saw the beam fold *inside* the mirror glass. Every reflective builder modelled its
substrate straddling the object origin, so the coated face stood proud of the REFLECT plane the
tracer actually folds at: 3 mm on a mirror, 1.5 mm on a dichroic, 2.5 mm on a grating. The mesh is
now slid so the surface the **axial ray** strikes sits on that plane.

## Measurement corrected the obvious fix twice

Both corrections are the substance of this PR, not footnotes.

**Seating the flat face is not enough for a curved mirror.** Its mesh is a spherical cap with a
*fixed cosmetic* sag (2 mm; the focal power comes from `radius_curv`, never from the mesh), so
seating the rim leaves the apex — the point the on-axis ray actually hits — off the plane.
Ray-casting down the local axis after the naive fix measured concave at `-2.000` and convex at
`+2.000`. The seat depth is now read from the profile itself so the two cannot drift apart.

**The grating needed no work at all**, though its frontmost vertex sits 2.2 mm proud — that vertex
is an off-axis groove peak, and the axial hit was already `0.000`. Fixing what the first
measurement seemed to show would have moved a correct optic.

| builder | axial hit before | after |
|---|---|---|
| mirror flat | 3.000 | **0.000** |
| mirror concave | -2.000 | **0.000** |
| mirror convex | +2.000 | **0.000** |
| dichroic | 1.500 | **0.000** |
| grating | 0.000 | 0.000 (already correct) |
| beamsplitter | — | untouched, coating is the internal 45° diagonal |
| retroreflector | — | untouched, angle-insensitive corner cube |

The last two are exempt **deliberately**, and the two exemptions do not rest on equally strong
evidence — measured, not assumed:

- **Beamsplitter — verified.** Its mesh is symmetric about the origin (`[-12.500 .. +12.500]`) and
  its `REFLECT` port sits at the cube centre `(0,0,0)`, so the internal 45° coated diagonal does
  pass through the origin. Seating it would introduce the very error this PR fixes.
- **Retroreflector — exempt on physics, with one thing unverified.** Its mesh is *not* centred
  (`[-15.000 .. +7.750]`, front aperture at `+7.75`, `REFLECT` at `0`), so the beam does fold ~7.75 mm
  inside the body. That is correct rather than a bug: a corner cube reflects off three *internal*
  facets, so unlike a front-surface mirror its coating is not the front face and seating it would be
  wrong. **Not verified:** whether that internal fold point coincides with the true trihedral apex.
  That is a pre-existing modelling question, unchanged by this PR and distinct from #25.

## Second commit: a regression this PR introduced, found in self-review

Seating moved the mesh relative to the origin — but `_build_mount` lays every mount part out *from*
that origin, assuming the substrate straddles it. The mount stayed put while the glass slid out of
it. Measured on a dressed bench along the optic axis:

```
                before (broken)        after
glass           [-6.000 ..  0.000]     [-6.000 ..  0.000]
KMplate         [-4.000 ..  2.000]     [-7.000 .. -1.000]   bore front was cutting 2 mm through the coating
KMretainer      [ 2.400 ..  3.600]     [ 0.000 ..  1.200]   the "physical stop for the mirror edge" was stopping air
```

`test_mesh_health` did not catch it — it counts parts and checks mesh validity, not whether an optic
sits correctly in its holder. Nothing in the suite asserted that relationship at all. The seat shift
is now recorded on the object and the mount frame follows it; optics that were never seated read
`0.0` and take the original path untouched.

## Verification

`test_optics` **547/547**, `test_mesh_health` PASS (30 element meshes, 311 mount parts),
`test_validation` **325/325**.

Negative controls, all three run: with the seating removed all five axial checks fail; with only the
flat case fixed exactly the two curved ones fail; with the mount frame left unshifted the ring check
fails.

**No traced number changed.** The `green_doubler` and `michelson` segment digests are identical to
`main` (`4e3a3a25…`, `8d4b7be4…`) — the tracer reads ports and `matrix_world`, never the mesh, and
mounts are decoration that is never traced.

## One test moved, and was proven an artefact before it was touched

`_frontrange()` selected front-half verts with an absolute `z > 0.1`, which assumed the substrate
straddled the origin. Once seated, no vertex cleared it and curved and flat both returned `0.0` — a
shape regression reported where the shape was unchanged. Measuring relative to the mesh's own extent
showed the curvature intact (`2.0000` curved vs `0.5000` flat) *before* the selector was changed to
be position-independent.

## Not fixed here, flagged deliberately

The `IN` port offsets are now stale magic numbers: dichroic `1.5` and grating `2.5` were *exactly*
the old face positions, so those ports now float half a substrate-thickness in front of the glass.
Untouched because moving a port changes behaviour (alignment, aperture checks), which is outside
this issue. No physics consequence for these elements — the one calculation that treats `IN` as the
plate face is the parasitic etalon, and `PARASITIC_PLATE_TYPES` is `('PASSTHROUGH','FILTER','ATTENUATOR')`,
none of which is touched here. Worth its own issue.
