### PR TITLE
Entry port on the face, seat the deformable mirror, document the corner cube (#29, #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Fixed — the entry port marks the face, and the deformable mirror gets seated too
+- **`IN` ports sit on the coated face** ([#29](https://github.com/emircbngl/blender-optics-simulator/issues/29)). #25 moved the glass and left the ports behind, and
+  two of those offsets had been chosen to *be* the face: dichroic `1.5`, grating `2.5`. They ended
+  up floating half a substrate-thickness in front of the glass, denoting nothing. They now coincide
+  with `REFLECT` — for a front-surface optic the beam enters exactly where it turns.
+  The trace is untouched (`interaction_surface()` takes the REFLECT plane for every `REFLECTIVE`
+  element and falls back to `IN` only for transmissive ones), but the auto-alignment **residual
+  reporting was wrong** and is now right: the aim point had been off the real interaction surface,
+  inflating errors that did not exist. On the bundled benches `GD_Dichroic`'s position error drops
+  from 1.2186 to 0.5999 mm and `GD_KTP`'s angular error from 0.4135° to 0.000007°, while the genuine
+  3.9725° misalignment of `MI_M_fixed` is reported unchanged — the phantom term went, the real one
+  stayed.
+- **The deformable mirror was missed by #25.** `DEFORMABLE_MIRROR` is in the tracer's `REFLECTIVE`
+  tuple and folds the beam at its REFLECT plane like any mirror, but only mirror/dichroic/grating
+  were seated. Its face stood 2 mm proud and the beam turned inside the faceplate. Now seated, and
+  the axial-hit guard covers every seated builder so the gap cannot reopen.
+
+### Documented — the corner cube is a thin-element idealization
+- **Retroreflector OPL** ([#30](https://github.com/emircbngl/blender-optics-simulator/issues/30)). The trace turns the beam on the REFLECT plane and charges nothing
+  for the trihedral depth. A real corner cube runs in to the apex and back, adding `2d` of path
+  (`2nd` solid) — a term that is *exact* and identical for every ray in the aperture, verified by
+  tracing three perpendicular mirrors (six entry points, `2d` to within 1e-9, independent of entry
+  point). It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
+  cosmetic proportion, and the tracer never reads the mesh — so there is no physical depth to
+  charge for. Direction and power are right; OPL is the thin-element value. In an interferometer
+  the missing `2d` is a constant piston in that arm: it shifts fringe position without distorting
+  the wavefront. Now stated where a physicist would look, in the tracer branch itself.
+
 ### Fixed — the drawn beam folds on the coating, not inside the glass
 - **Reflective optics are seated on the plane they reflect from** ([#25](https://github.com/emircbngl/blender-optics-simulator/issues/25)). Every reflective builder
   modelled its substrate straddling the object origin, so the coated face stood proud of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ semantic versioning.
 
 ### Documented — the corner cube is a thin-element idealization
 - **Retroreflector OPL** ([#30](https://github.com/emircbngl/blender-optics-simulator/issues/30)). The trace turns the beam on the REFLECT plane and charges nothing
-  for the trihedral depth. A real corner cube runs in to the apex and back, adding `2d` of path
-  (`2nd` solid) — a term that is *exact* and identical for every ray in the aperture, verified by
-  tracing three perpendicular mirrors (six entry points, `2d` to within 1e-9, independent of entry
-  point). It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
+  for the trihedral depth. A real corner cube runs in to the apex and back, adding `2d` of path —
+  for a **hollow** cube a term that is *exact* and identical for every ray in the aperture, verified
+  by tracing three perpendicular mirrors (six entry points, `2d` to within 1e-9, independent of
+  entry point). A solid glass cube is `2nd` **at normal incidence only**, and that case is not
+  verified here: the entrance face refracts, so off-normal the internal path is not a plain `2d`
+  scaled by `n`. It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
   cosmetic proportion, and the tracer never reads the mesh — so there is no physical depth to
   charge for. Direction and power are right; OPL is the thin-element value. In an interferometer
   the missing `2d` is a constant piston in that arm: it shifts fringe position without distorting

--- a/optical_alignment_sim/elements_generic.py
+++ b/optical_alignment_sim/elements_generic.py
@@ -939,7 +939,12 @@ def mirror(name, loc, in_dir, out_dir, coll=None, size=25.0, mirror_curve='FLAT'
     # seating the rim would still turn the beam 2 mm off the surface it visibly strikes -- #25 again,
     # smaller. Taken from the profile itself so the two cannot drift apart.
     _seat_optical_face(o, face_z)
-    _add_port(o, "IN", 'IN', (0, 0, 2.0), (0, 0, 1), size * 0.5)
+    # IN sits ON the coated face, coincident with REFLECT: for a front-surface optic the beam
+    # enters exactly where it turns. The old standoff was the PRE-#25 face position, which stopped
+    # denoting anything once the glass was seated (#29). interaction_surface() takes the REFLECT
+    # plane for every REFLECTIVE element and falls back to IN only for transmissive ones, so this
+    # moves the auto-alignment AIM POINT onto the real reflection point and nothing else.
+    _add_port(o, "IN", 'IN', (0, 0, 0), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _z_to(n))     # local +Z (face/REFLECT normal) -> bisector n
     return o
@@ -1830,7 +1835,12 @@ def dichroic(name, loc, in_dir, reflect_dir, coll=None, split=0.5, size=25.0,
     _tag(o, 'DICHROIC', split_ratio=split, clear_aperture=size * 0.5, reflectivity=1.0,
          pass_type=pass_type, cut_nm=cut_nm)
     _seat_optical_face(o, 1.5)      # 3 mm plate: the coated +Z face is the optical surface
-    _add_port(o, "IN", 'IN', (0, 0, 1.5), (0, 0, 1), size * 0.5)
+    # IN sits ON the coated face, coincident with REFLECT: for a front-surface optic the beam
+    # enters exactly where it turns. The old standoff was the PRE-#25 face position, which stopped
+    # denoting anything once the glass was seated (#29). interaction_surface() takes the REFLECT
+    # plane for every REFLECTIVE element and falls back to IN only for transmissive ones, so this
+    # moves the auto-alignment AIM POINT onto the real reflection point and nothing else.
+    _add_port(o, "IN", 'IN', (0, 0, 0), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _roll_upright(_z_to(n), n))   # square plate upright, not a diamond
     return o
@@ -1853,7 +1863,12 @@ def grating(name, loc, in_dir, out_dir, coll=None, size=25.0, lines_per_mm=1200.
     _tag(o, 'GRATING', clear_aperture=size * 0.5, reflectivity=0.8,
          lines_per_mm=lines_per_mm, grating_order=order, grating_profile=grating_profile)
     _seat_optical_face(o, 2.5)      # 5 mm plate: the ruled +Z face is the optical surface
-    _add_port(o, "IN", 'IN', (0, 0, 2.5), (0, 0, 1), size * 0.5)
+    # IN sits ON the coated face, coincident with REFLECT: for a front-surface optic the beam
+    # enters exactly where it turns. The old standoff was the PRE-#25 face position, which stopped
+    # denoting anything once the glass was seated (#29). interaction_surface() takes the REFLECT
+    # plane for every REFLECTIVE element and falls back to IN only for transmissive ones, so this
+    # moves the auto-alignment AIM POINT onto the real reflection point and nothing else.
+    _add_port(o, "IN", 'IN', (0, 0, 0), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _roll_upright(_z_to(n), n))   # square upright + grooves vertical
     return o
@@ -1923,7 +1938,16 @@ def deformable_mirror(name, loc, in_dir, out_dir, coll=None, size=25.0, command=
     _join(o, housing)
     _tag(o, 'DEFORMABLE_MIRROR', clear_aperture=size * 0.5, reflectivity=1.0)
     o.optics.dm_command = _pad15(command)
-    _add_port(o, "IN", 'IN', (0, 0, 2.0), (0, 0, 1), size * 0.5)
+    # DEFORMABLE_MIRROR is in the tracer's REFLECTIVE tuple, so it folds the beam at its REFLECT
+    # plane like any mirror -- but #25 seated only mirror/dichroic/grating and missed it, leaving
+    # its face 2 mm proud and the beam turning inside the faceplate.
+    _seat_optical_face(o, 2.0)      # 4 mm faceplate over the actuator housing
+    # IN sits ON the coated face, coincident with REFLECT: for a front-surface optic the beam
+    # enters exactly where it turns. The old standoff was the PRE-#25 face position, which stopped
+    # denoting anything once the glass was seated (#29). interaction_surface() takes the REFLECT
+    # plane for every REFLECTIVE element and falls back to IN only for transmissive ones, so this
+    # moves the auto-alignment AIM POINT onto the real reflection point and nothing else.
+    _add_port(o, "IN", 'IN', (0, 0, 0), (0, 0, 1), size * 0.5)
     _add_port(o, "REFLECT", 'REFLECT', (0, 0, 0), (0, 0, 1), size * 0.5)
     _set_matrix(o, Vector(loc), _z_to(n))     # local +Z (REFLECT normal) -> bisector n
     return o

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -1340,6 +1340,20 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             # corner cube does not, so a specular model reports misalignment that does not
             # physically exist. Tier-1 polarization: ideal scalar reflectivity (a real cube
             # rotates polarization per sextant; out of scope for the chief-ray model).
+            #
+            # THIN-ELEMENT IDEALIZATION -- the internal path is deliberately NOT modelled (#30).
+            # The beam turns on the REFLECT plane and the trihedral depth costs it nothing. A real
+            # corner cube instead runs in to the apex and back out, adding 2*d of geometric path
+            # (2*n*d in a solid cube). That term is EXACT, not approximate, and identical for every
+            # ray in the aperture -- the constant-path property corner cubes are used for. Verified
+            # by tracing three perpendicular mirrors: six entry points, total path 2d to within
+            # 1e-9, independent of entry point.
+            # It is omitted because the element carries NO depth parameter -- the mesh's apex is a
+            # cosmetic proportion (_corner_cube uses size*0.6) and this tracer never reads the mesh,
+            # so there is no physical depth here to charge for. Consequence to know: direction and
+            # power are right, but OPL through a retroreflector is the thin-element value. In an
+            # interferometer the missing 2*d is a constant piston in that arm -- it shifts fringe
+            # POSITION without distorting the wavefront. Model the standoff explicitly if it matters.
             nd = (-ray.dir).normalized()
             if ray.evec is not None:
                 a = math.sqrt(max(op.reflectivity, 0.0))

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -1343,11 +1343,14 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             #
             # THIN-ELEMENT IDEALIZATION -- the internal path is deliberately NOT modelled (#30).
             # The beam turns on the REFLECT plane and the trihedral depth costs it nothing. A real
-            # corner cube instead runs in to the apex and back out, adding 2*d of geometric path
-            # (2*n*d in a solid cube). That term is EXACT, not approximate, and identical for every
-            # ray in the aperture -- the constant-path property corner cubes are used for. Verified
-            # by tracing three perpendicular mirrors: six entry points, total path 2d to within
-            # 1e-9, independent of entry point.
+            # corner cube instead runs in to the apex and back out, adding 2*d of geometric path.
+            # For a HOLLOW (mirror) cube that term is EXACT, not approximate, and identical for
+            # every ray in the aperture -- the constant-path property corner cubes are used for.
+            # Verified by tracing three perpendicular mirrors: six entry points, total path 2d to
+            # within 1e-9, independent of entry point.
+            # A SOLID glass cube is 2*n*d at NORMAL INCIDENCE ONLY, and that case is NOT verified
+            # here: the entrance face refracts, so off-normal the internal geometry is no longer a
+            # plain 2d scaled by n. Treat 2*n*d as the normal-incidence figure, not a general one.
             # It is omitted because the element carries NO depth parameter -- the mesh's apex is a
             # cosmetic proportion (_corner_cube uses size*0.6) and this tracer never reads the mesh,
             # so there is no physical depth here to charge for. Consequence to know: direction and

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -640,10 +640,22 @@ for _lbl, _mk in (("flat mirror",    lambda: eg.mirror("S_f", (0, 0, 0), (1, 0, 
                                                        mirror_curve='CONVEX', radius_curv=300.0)),
                   ("dichroic",       lambda: eg.dichroic("S_d", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll)),
                   ("grating",        lambda: eg.grating("S_g", (0, 0, 0), (1, 0, 0), (0, 1, 0), coll=_mcoll,
-                                                        lines_per_mm=1200.0))):
-    _z = _axial_hit_z(_mk())
+                                                        lines_per_mm=1200.0)),
+                  # deformable mirror is in the tracer's REFLECTIVE tuple too -- #25 missed it
+                  ("deformable mirror", lambda: eg.deformable_mirror("S_dm", (0, 0, 0), (1, 0, 0), (0, 1, 0),
+                                                                     coll=_mcoll))):
+    _el = _mk()
+    _z = _axial_hit_z(_el)
     check("#25: %s turns the beam on its coated face (axial hit on the REFLECT plane)" % _lbl,
           _z is not None and abs(_z) < 1e-3, "axial hit z = %s" % ("miss" if _z is None else "%.3f" % _z))
+    # #29: the entry port must mark that same face -- a front-surface optic is entered where it turns
+    _pin = next((q for q in _el.optics.ports if q.role == 'IN'), None)
+    _prf = next((q for q in _el.optics.ports if q.role == 'REFLECT'), None)
+    check("#29: %s entry port sits on the coated face, not at a stale standoff" % _lbl,
+          _pin is not None and _prf is not None
+          and (_pin.local_position - _prf.local_position).length < 1e-6,
+          "IN %s vs REFLECT %s" % (None if not _pin else tuple(round(v, 3) for v in _pin.local_position),
+                                   None if not _prf else tuple(round(v, 3) for v in _prf.local_position)))
 
 # --- #25 follow-up: seating the glass must not leave the MOUNT behind -------------------------
 # The opto-mechanics lays every part out from the object origin assuming the substrate straddles it.


### PR DESCRIPTION
Closes #29. Closes #30. Also fixes a builder that #25 (PR #28) missed.

## #29 — the entry port marks the face again

#25 slid the glass and deliberately left ports alone. But two of those offsets had been chosen to
*be* the face: dichroic `1.5`, grating `2.5`. Once the glass moved they floated half a
substrate-thickness in front of it, denoting nothing. `IN` now coincides with `REFLECT` — a
front-surface optic is entered exactly where it turns.

**The trace does not move.** `interaction_surface()` takes the REFLECT plane for every `REFLECTIVE`
element and falls back to `IN` only for transmissive ones; the segment digests confirm it.

**What did move is the auto-alignment residual, which was wrong.** It aimed at a point that is not
on the interaction surface, so it charged for a standoff:

```
GD_Dichroic  pos_err   1.218593110 -> 0.599974406    phantom halved away
GD_KTP       ang_err   0.413541733 -> 0.000006988    phantom gone
MI_M_fixed   ang_err   3.972470400 -> 3.972470400    genuine, reported unchanged
```

The metric did not go blind — the real misalignment is still reported to the last digit.

## #25 residual — the deformable mirror was missed

`DEFORMABLE_MIRROR` is in the tracer's `REFLECTIVE` tuple and folds at its REFLECT plane like any
mirror, but PR #28 seated only mirror/dichroic/grating. Measured axial hit: **+2.000** — the beam
turned inside the faceplate, the exact defect #25 reported.

Found by walking every member of `REFLECTIVE` instead of the three I had in mind, which is how the
first pass should have been done. `PRISM_MIRROR` has no generic builder (catalog meshes), so there
is nothing to seat there. The axial-hit guard now covers every seated builder.

## #30 — the corner cube is a thin-element idealization, now said so

The source already settled the question: `_corner_cube` is documented "Cosmetic" and its depth is
`size * 0.6` = 15 mm — a proportion, not an optical spec. So the model is an ideal thin
retroreflector *by design*; what was missing is that nothing said so where a physicist would look,
while the 15 mm mesh apex implied otherwise.

**No physics was added, deliberately.** Charging OPL from a cosmetic proportion would break the
project's own rule that the tracer never reads the mesh. Instead the idealization and its
consequence are now stated in the tracer branch: the omitted term is `2d`, and for a **hollow** cube
that is exact and identical for every ray in the aperture — verified by tracing three perpendicular
mirrors, six entry points, `2d` to within 1e-9, independent of entry point. In an interferometer the
missing `2d` is a constant piston in that arm: it shifts fringe position without distorting the
wavefront.

A solid glass cube is `2nd` **at normal incidence only**, and that case is explicitly marked
unverified — the entrance face refracts, so off-normal the internal path is not a plain `2d` scaled
by `n`. The second commit exists to scope that claim back to what the measurement actually covered.

## Verification

`test_optics` **554/554** (was 547), `test_mesh_health` PASS (30 element meshes, 311 mount parts),
`test_validation` **325/325**. Segment digests for `green_doubler` and `michelson` identical to
`main`.

Negative control: restoring the dichroic standoff and un-seating the deformable mirror fails exactly
those two checks and no others.