### PR TITLE
Correct the corner-cube verification: the old test was degenerate (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ semantic versioning.
   exit exactly antiparallel. The path is independent of **both** entry point and incidence angle
   within the acceptance cone, the three reflections composing to a point inversion through the apex. A solid glass cube is `2nd` **at normal incidence only** — also measured, by tracing
   the same trihedral behind a refracting entrance face: exact at 0°, then growing with angle
-  (+0.075 mm at 5°, +1.205 mm at 20° for n=1.5145, d=15 mm) while staying entry-point independent. It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
+  (+0.0754 mm at 5°, +1.2044 mm at 20°, for d=15 mm and `n` taken from the module's own
+  `sellmeier_n(633, 'N-BK7', 20)` = 1.515082) while staying entry-point independent. It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
   cosmetic proportion, and the tracer never reads the mesh — so there is no physical depth to
   charge for. Direction and power are right; OPL is the thin-element value. In an interferometer
   the missing `2d` is a constant piston in that arm: it shifts fringe position without distorting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ semantic versioning.
 - **Retroreflector OPL** ([#30](https://github.com/emircbngl/blender-optics-simulator/issues/30)). The trace turns the beam on the REFLECT plane and charges nothing
   for the trihedral depth. A real corner cube runs in to the apex and back, adding `2d` of path —
   for a **hollow** cube a term that is *exact* and identical for every ray in the aperture, verified
-  by tracing three perpendicular mirrors (six entry points, `2d` to within 1e-9, independent of
-  entry point). A solid glass cube is `2nd` **at normal incidence only**, and that case is not
+  by ray-tracing the actual trihedral — facets as quarter-planes bounding one octant, 3 incidence
+  directions × 5 entry points, every ray touching all three facets, `2d` to within 4e-15 with the
+  exit exactly antiparallel. The path is independent of **both** entry point and incidence angle
+  within the acceptance cone, the three reflections composing to a point inversion through the apex. A solid glass cube is `2nd` **at normal incidence only**, and that case is not
   verified here: the entrance face refracts, so off-normal the internal path is not a plain `2d`
   scaled by `n`. It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
   cosmetic proportion, and the tracer never reads the mesh — so there is no physical depth to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ semantic versioning.
   by ray-tracing the actual trihedral — facets as quarter-planes bounding one octant, 3 incidence
   directions × 5 entry points, every ray touching all three facets, `2d` to within 4e-15 with the
   exit exactly antiparallel. The path is independent of **both** entry point and incidence angle
-  within the acceptance cone, the three reflections composing to a point inversion through the apex. A solid glass cube is `2nd` **at normal incidence only**, and that case is not
-  verified here: the entrance face refracts, so off-normal the internal path is not a plain `2d`
-  scaled by `n`. It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
+  within the acceptance cone, the three reflections composing to a point inversion through the apex. A solid glass cube is `2nd` **at normal incidence only** — also measured, by tracing
+  the same trihedral behind a refracting entrance face: exact at 0°, then growing with angle
+  (+0.075 mm at 5°, +1.205 mm at 20° for n=1.5145, d=15 mm) while staying entry-point independent. It is omitted deliberately: the element carries no depth parameter, the mesh apex is a
   cosmetic proportion, and the tracer never reads the mesh — so there is no physical depth to
   charge for. Direction and power are right; OPL is the thin-element value. In an interferometer
   the missing `2d` is a constant piston in that arm: it shifts fringe position without distorting

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -1357,10 +1357,11 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             # ONE facet and measured a single flat mirror at distance d, for which 2d is true by
             # definition. The claim was right; that test could not establish it.)
             # A SOLID glass cube is 2*n*d at NORMAL INCIDENCE ONLY -- measured, by tracing the same
-            # trihedral behind a flat entrance face with Snell refraction in and out (n=1.5145,
-            # d=15): at 0 deg the internal path is 2d exactly and the OPL is 2*n*d to 4e-15, and it
-            # then GROWS with angle (+0.075 mm at 5 deg, +1.205 mm at 20 deg) while staying
-            # independent of entry point. So 2*n*d is the normal-incidence figure, not a general one.
+            # trihedral behind a flat entrance face with Snell refraction in and out (d=15 mm, n from
+            # this module's own sellmeier_n(633, 'N-BK7', 20) = 1.515082): at 0 deg the internal path
+            # is 2d exactly and the OPL is 2*n*d to 4e-15, then it GROWS with angle (+0.0754 mm at
+            # 5 deg, +1.2044 mm at 20 deg) while staying independent of entry point. So 2*n*d is the
+            # normal-incidence figure, not a general one.
             # It is omitted because the element carries NO depth parameter -- the mesh's apex is a
             # cosmetic proportion (_corner_cube uses size*0.6) and this tracer never reads the mesh,
             # so there is no physical depth here to charge for. Consequence to know: direction and

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -1356,9 +1356,11 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             # at planes x=0/y=0/z=0 has no x or y velocity, so it can only ever reach z=0. It hit
             # ONE facet and measured a single flat mirror at distance d, for which 2d is true by
             # definition. The claim was right; that test could not establish it.)
-            # A SOLID glass cube is 2*n*d at NORMAL INCIDENCE ONLY, and that case is NOT verified
-            # here: the entrance face refracts, so off-normal the internal geometry is no longer a
-            # plain 2d scaled by n. Treat 2*n*d as the normal-incidence figure, not a general one.
+            # A SOLID glass cube is 2*n*d at NORMAL INCIDENCE ONLY -- measured, by tracing the same
+            # trihedral behind a flat entrance face with Snell refraction in and out (n=1.5145,
+            # d=15): at 0 deg the internal path is 2d exactly and the OPL is 2*n*d to 4e-15, and it
+            # then GROWS with angle (+0.075 mm at 5 deg, +1.205 mm at 20 deg) while staying
+            # independent of entry point. So 2*n*d is the normal-incidence figure, not a general one.
             # It is omitted because the element carries NO depth parameter -- the mesh's apex is a
             # cosmetic proportion (_corner_cube uses size*0.6) and this tracer never reads the mesh,
             # so there is no physical depth here to charge for. Consequence to know: direction and

--- a/optical_alignment_sim/tracer.py
+++ b/optical_alignment_sim/tracer.py
@@ -1346,8 +1346,16 @@ def trace_scene(scene, mode='AUTO', max_segments=64, max_depth=12):
             # corner cube instead runs in to the apex and back out, adding 2*d of geometric path.
             # For a HOLLOW (mirror) cube that term is EXACT, not approximate, and identical for
             # every ray in the aperture -- the constant-path property corner cubes are used for.
-            # Verified by tracing three perpendicular mirrors: six entry points, total path 2d to
-            # within 1e-9, independent of entry point.
+            # Verified by ray-tracing the actual trihedral -- apex at the origin, facets the three
+            # QUARTER-planes bounding one octant, so a hit only counts inside the facet: 3 incidence
+            # directions x 5 entry points, every ray touching all THREE facets (bounce orders zxy,
+            # xyz, xzy, yxz, zyx all occur), total path 2d to within 4e-15 and the exit exactly
+            # antiparallel. The path is independent of BOTH entry point and incidence angle within
+            # the acceptance cone -- the three reflections compose to a point inversion through the
+            # apex. (An earlier note here claimed this from a degenerate test: a ray sent along -Z
+            # at planes x=0/y=0/z=0 has no x or y velocity, so it can only ever reach z=0. It hit
+            # ONE facet and measured a single flat mirror at distance d, for which 2d is true by
+            # definition. The claim was right; that test could not establish it.)
             # A SOLID glass cube is 2*n*d at NORMAL INCIDENCE ONLY, and that case is NOT verified
             # here: the entrance face refracts, so off-normal the internal geometry is no longer a
             # plain 2d scaled by n. Treat 2*n*d as the normal-incidence figure, not a general one.


### PR DESCRIPTION
Comments and changelog only. The physics the tracer implements is untouched; what was wrong is the
**evidence cited** for a claim about physics it deliberately does not implement.

## The published verification did not test a corner cube

The note added with #30 said the `2d` constant-path property was "verified by tracing three
perpendicular mirrors: six entry points … independent of entry point". It sent every ray along `-Z`
at the planes `x=0`, `y=0`, `z=0`. A ray with zero x and y velocity can never reach the `x=0` or
`y=0` planes — instrumenting the original script reports **`bounces=1`** for all six entry points,
always the same `z` facet. What was measured was a single flat mirror at distance `d`, for which a
`2d` round trip is true by definition.

Raised in review by Sol; verified here before accepting it.

## Re-verified properly — and the conclusion gets stronger

Apex at the origin, facets as the three **quarter-planes** bounding one octant, so a plane crossing
only counts when it lands inside the facet. Bounce order left to whatever the ray reaches; entry
points spread across the aperture on a basis perpendicular to the incidence direction.

```
3 incidence directions x 5 entry points
every ray touches all THREE facets  (orders zxy, xyz, xzy, yxz, zyx all observed)
total path 30.000000000 for d = 15    |error| <= 3.6e-15
exit direction antiparallel to entry, error 0.0
```

The path is independent of **both** entry point and incidence angle within the acceptance cone — the
three reflections compose to a point inversion through the apex. The old test could not have shown
the second half.

## The solid-cube case is now measured too

It had been marked unverified. Traced: the same trihedral behind a flat entrance face with Snell
refraction in and out, `d = 15 mm`, `n` from **this module's own** `sellmeier_n(633, 'N-BK7', 20)`
= `1.515082`.

```
theta_in   bounces   geometric path   OPL = n*L        OPL - 2nd
 0 deg     3         30.000000000     45.452460000     +0.000000
 5 deg     3         30.049761161     45.527852239     +0.075392
20 deg     3         30.794917216     46.656824765     +1.204365
```

Exact at normal incidence, growing with angle, entry-point independent to 3.6e-15. So `2nd` is the
normal-incidence figure, not a general one — the qualifier was right, and is now measured.

## Three corrections, one root cause

Worth stating plainly, because the commits record it: the degenerate test, then computing the
internal path from an assumed `2d/cos(theta_r)` instead of tracing it, then writing `n = 1.5145`
from memory when the module's own Sellmeier says `1.515082`. All three are the same move — reaching
for what I already "knew" instead of for the code that was right there. The traced numbers happened
to agree with the assumed formula, but agreement found afterwards is not evidence gathered
beforehand.

`tracer.py` parses; the publish contract's physics and beamcolor selftests pass.