### PR TITLE
Release v0.29.1 — the beam turns on the coating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **Blender Optics Simulator** (`optical_alignment_sim`
 here. The format follows [Keep a Changelog](https://keepachangelog.com/), and the project uses
 semantic versioning.
 
-## [Unreleased]
+## [0.29.1] — The beam turns on the coating, the mount follows the glass, and a verification that finally tested something — 2026-08-21
 
 ### Fixed — the entry port marks the face, and the deformable mirror gets seated too
 - **`IN` ports sit on the coated face** ([#29](https://github.com/emircbngl/blender-optics-simulator/issues/29)). #25 moved the glass and left the ports behind, and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
   - gaussian-beam
   - polarization
   - mcp
-version: "0.29.0"
-date-released: "2026-08-18"
+version: "0.29.1"
+date-released: "2026-08-21"
 doi: "10.5281/zenodo.20778997"
 identifiers:
   - type: doi

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ ready-to-paste APA / BibTeX.
   author  = {Çobanoğlu, Muhammet Emir},
   title   = {Blender Optics Simulator},
   year    = {2026},
-  version = {0.29.0},
+  version = {0.29.1},
   doi     = {10.5281/zenodo.20778997},
   license = {GPL-3.0-or-later},
   url     = {https://github.com/emircbngl/blender-optics-simulator}

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,10 +25,10 @@
 <body>
 <div class="wrap">
   <h1>Blender Optics Simulator</h1>
-  <p class="tag">Live ray tracing &amp; auto-alignment for optical benches · v0.29.0</p>
+  <p class="tag">Live ray tracing &amp; auto-alignment for optical benches · v0.29.1</p>
 
   <p><b>One-click install (Blender 4.2+):</b></p>
-  <p><a class="cta" href="https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.29.0/optical_alignment_sim-0.29.0.zip?repository=https%3A%2F%2Femircbngl.github.io%2Fblender-optics-simulator%2Findex.json&blender_version_min=4.2.0">⤓ Drag this into Blender to install</a></p>
+  <p><a class="cta" href="https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.29.1/optical_alignment_sim-0.29.1.zip?repository=https%3A%2F%2Femircbngl.github.io%2Fblender-optics-simulator%2Findex.json&blender_version_min=4.2.0">⤓ Drag this into Blender to install</a></p>
   <p class="hint">Drag the button onto an open Blender window. Blender installs the add-on
      <b>and</b> subscribes you to update notifications — no URL to type. Make sure
      <b>Edit ▸ Preferences ▸ System ▸ Network ▸ Allow Online Access</b> is on.</p>

--- a/docs/index.json
+++ b/docs/index.json
@@ -7,7 +7,7 @@
    "id": "optical_alignment_sim",
    "name": "Optics Simulator",
    "tagline": "Live ray tracing & auto-alignment for optical benches",
-   "version": "0.29.0",
+   "version": "0.29.1",
    "type": "add-on",
    "maintainer": "Emir <emircbngl@gmail.com>",
    "license": [
@@ -22,9 +22,9 @@
    "tags": [
     "Render"
    ],
-   "archive_url": "https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.29.0/optical_alignment_sim-0.29.0.zip",
-   "archive_size": 457964,
-   "archive_hash": "sha256:d1e1f8a505ccd31e8274f44091e812017fdc9451cd12e0470a9685c322a16878"
+   "archive_url": "https://github.com/emircbngl/blender-optics-simulator/releases/download/v0.29.1/optical_alignment_sim-0.29.1.zip",
+   "archive_size": 459381,
+   "archive_hash": "sha256:8eb1387f46f5f4d4dfe7268abce6d156098f41a9bfe627b778a6e4fa739fa86e"
   }
  ]
 }

--- a/optical_alignment_sim/blender_manifest.toml
+++ b/optical_alignment_sim/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "optical_alignment_sim"
-version = "0.29.0"
+version = "0.29.1"
 name = "Optics Simulator"
 tagline = "Live ray tracing & auto-alignment for optical benches"
 maintainer = "Emir <emircbngl@gmail.com>"


### PR DESCRIPTION
Version bump only — the fixes themselves already landed in #28, #31 and #32. A correctness release:
no new features, no API change, so a patch by this project's own precedent (0.24.1–.3 were the same
shape).

## What ships

- **Reflective optics are seated on the plane they reflect from** (#25). A mirror's coating stood
  3 mm proud of the REFLECT plane, a dichroic's 1.5 mm, a grating's 2.5 mm, a curved mirror's apex a
  further 2 mm — the drawn beam folded inside the glass.
- **The mount follows the glass.** Seating the mesh alone left the KM retaining ring, the physical
  stop for the mirror edge, floating 3.6 mm clear of the face it retains.
- **The deformable mirror**, missed by the first pass, is seated too.
- **`IN` ports sit on the coated face** (#29) — which corrects auto-alignment *residual reporting*,
  not just tidiness: `GD_KTP`'s angular error drops from 0.4135° to 0.000007° while `MI_M_fixed`'s
  genuine 3.9725° is reported unchanged.
- **The corner cube's thin-element idealization is documented** (#30), and the verification behind
  it was corrected after review found the original test degenerate.

**No traced number changed anywhere in this release.** The `green_doubler` and `michelson` segment
digests are identical to v0.29.0 — the tracer reads ports and `matrix_world`, never the mesh.

## Artifacts — recomputed, not quoted

```
zip     dist/optical_alignment_sim-0.29.1.zip
size    459381 bytes    <- docs/index.json archive_size matches
sha256  8eb1387f46f5f4d4dfe7268abce6d156098f41a9bfe627b778a6e4fa739fa86e
                        <- recomputed from the zip, matches archive_hash
```

Built with `blender --command extension build`, then `tools/build_pages_repo.py` regenerated
`docs/index.json` + `docs/index.html`.

## Gates

`tools/check_release_consistency.py` **PASS** (pre mode, 0.29.1). `test_optics` **554/554**,
`test_mesh_health` PASS (30 element meshes, 311 mount parts), `test_validation` **325/325**.

## Still open after merge

The v0.29.1 Zenodo **version DOI** is not in `CITATION.cff` yet — Zenodo mints it when the GitHub
Release is published, so it lands in a follow-up commit. The concept DOI is unchanged and already
resolves to latest.