### PR TITLE
Record the v0.29.1 Zenodo version DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,6 +34,9 @@ identifiers:
     value: "10.5281/zenodo.20778997"
     description: "Concept DOI — always resolves to the latest version"
   - type: doi
+    value: "10.5281/zenodo.22047655"
+    description: "Version DOI for v0.29.1"
+  - type: doi
     value: "10.5281/zenodo.22001222"
     description: "Version DOI for v0.29.0"
   - type: doi


### PR DESCRIPTION
Follow-up to #33, as flagged there. Zenodo mints the version DOI when the GitHub Release is
published, so it could not go in the release commit.

Read back from Zenodo rather than assumed:

```
concept record 20778997 redirects to record 22047655
version DOI        10.5281/zenodo.22047655
metadata version   v0.29.1
publication_date   2026-08-21
```

`https://doi.org/10.5281/zenodo.22047655` resolves (302 → zenodo.org).

**README needs no change.** Every DOI it cites — the badge, the BibTeX block, the prose — is the
**concept** DOI, which is version-independent and always resolves to the latest release. Only
`CITATION.cff` carries the per-version list.

`CITATION.cff` still parses as YAML (24 identifiers, concept DOI first, v0.29.1 above v0.29.0).
`tools/check_release_consistency.py` PASS (pre mode, 0.29.1).